### PR TITLE
Refactor shared navbar and adopt official Pages build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,17 +5,36 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    
     steps:
-    - uses: actions/checkout@v3
-    
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/main'
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: . 
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ yarn-error.log*
 dist/
 build/
 out/
+_site/
+.jekyll-cache/
+.jekyll-metadata
 
 # Environment variables
 .env

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,0 +1,104 @@
+<nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between items-center py-2">
+            <a href="{{ '/index.html' | relative_url }}" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
+            <!-- Desktop nav -->
+            <div class="hidden md:flex items-center space-x-6">
+                <a href="{{ '/why-eternax.html' | relative_url }}" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
+                <div class="relative group">
+                    <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </span>
+                    <div class="nav-products-dropdown absolute left-0 top-full pt-1">
+                        <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
+                            <a href="{{ '/post-quantum-signature-security-ranking-2026.html' | relative_url }}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
+                                <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
+                            </a>
+                            <a href="{{ '/post-quantum-cryptography-risk-framework-for-institutions.html' | relative_url }}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
+                                <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
+                            </a>
+                            <a href="{{ '/already-broken-quantum-risk-report-q1-2026.html' | relative_url }}" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
+                                <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="relative group">
+                    <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </span>
+                    <div class="nav-products-dropdown absolute left-0 top-full pt-1">
+                        <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
+                            <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-settlement{% else %}{{ '/index.html#product-settlement' | relative_url }}{% endif %}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
+                                <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
+                            </a>
+                            <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-issuance{% else %}{{ '/index.html#product-issuance' | relative_url }}{% endif %}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
+                                <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
+                            </a>
+                            <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-migration{% else %}{{ '/index.html#product-migration' | relative_url }}{% endif %}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
+                                <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
+                            </a>
+                            <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-wallet{% else %}{{ '/index.html#product-wallet' | relative_url }}{% endif %}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
+                                <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
+                            </a>
+                            <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-venues{% else %}{{ '/index.html#product-venues' | relative_url }}{% endif %}" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
+                                <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <a href="{% if page.url == '/' or page.url == '/index.html' %}#team{% else %}{{ '/index.html#team' | relative_url }}{% endif %}" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
+                <a href="{{ '/blogs/index.html' | relative_url }}" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
+                <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
+                    Contact Us
+                </a>
+            </div>
+            <!-- Mobile hamburger -->
+            <div class="md:hidden">
+                <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
+                    <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
+                        <path d="M3 6h18M3 12h18M3 18h18" />
+                    </svg>
+                    <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
+                        <path d="M6 6l12 12M6 18L18 6" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu -->
+        <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
+            <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
+                <a href="{{ '/why-eternax.html' | relative_url }}" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
+                <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
+                <a href="{{ '/post-quantum-signature-security-ranking-2026.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
+                <a href="{{ '/post-quantum-cryptography-risk-framework-for-institutions.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
+                <a href="{{ '/already-broken-quantum-risk-report-q1-2026.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
+                <a href="{{ '/blogs/index.html' | relative_url }}" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
+                <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
+                <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-settlement{% else %}{{ '/index.html#product-settlement' | relative_url }}{% endif %}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
+                <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-issuance{% else %}{{ '/index.html#product-issuance' | relative_url }}{% endif %}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
+                <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-migration{% else %}{{ '/index.html#product-migration' | relative_url }}{% endif %}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
+                <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-wallet{% else %}{{ '/index.html#product-wallet' | relative_url }}{% endif %}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
+                <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-venues{% else %}{{ '/index.html#product-venues' | relative_url }}{% endif %}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
+                <a href="{% if page.url == '/' or page.url == '/index.html' %}#team{% else %}{{ '/index.html#team' | relative_url }}{% endif %}" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
+                <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
+                    Contact Us
+                </a>
+            </div>
+        </div>
+    </div>
+</nav>

--- a/about.html
+++ b/about.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -230,112 +232,7 @@
 </head>
 <body class="font-sans" itemscope itemtype="https://schema.org/WebPage">
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <div class="flex items-center">
-                    <a href="./index.html" class="text-xl font-bold" style="color: var(--fg);">eternaX</a>
-                </div>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="./why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="./post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="./post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="./already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="./index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="./index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="./index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="./index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="./index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="./index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="blogs/index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="./why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-                    <a href="./post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-                    <a href="./post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-                    <a href="./already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <a href="blogs/index.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="./index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="./index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="./index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="./index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="./index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="./index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <!-- PAGE CONTENT STARTS HERE -->
     <main class="pt-20">

--- a/already-broken-quantum-risk-report-q1-2026.html
+++ b/already-broken-quantum-risk-report-q1-2026.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1451,111 +1453,7 @@
 </head>
 <body>
   <!-- Navigation -->
-  <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between items-center py-2">
-            <div class="flex items-center">
-                <a href="./index.html" class="text-xl font-bold" style="color: var(--fg);">eternaX</a>
-            </div>
-            <!-- Desktop nav -->
-            <div class="hidden md:flex items-center space-x-6">
-              <a href="./why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-              <div class="relative group">
-                <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </span>
-                <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                    <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                        <a href="post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                            <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                            <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                        </a>
-                        <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                            <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                            <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                        </a>
-                        <a href="already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                            <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                            <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                        </a>
-                    </div>
-                </div>
-            </div>
-                <div class="relative group">
-                    <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </span>
-                    <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                        <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                            <a href="./index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                            </a>
-                            <a href="./index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                            </a>
-                            <a href="./index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                            </a>
-                            <a href="./index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                            </a>
-                            <a href="./index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                            </a>
-                        </div>
-                    </div>
-                </div>
-                <a href="./index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                <a href="blogs/index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                    Contact Us
-                </a>
-            </div>
-            <!-- Mobile hamburger -->
-            <div class="md:hidden">
-                <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                    <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                        <path d="M3 6h18M3 12h18M3 18h18" />
-                    </svg>
-                    <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                        <path d="M6 6l12 12M6 18L18 6" />
-                    </svg>
-                </button>
-            </div>
-        </div>
-        <!-- Mobile menu -->
-        <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-            <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-              <a href="why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-              <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                <a href="./index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                <a href="./index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                <a href="./index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                <a href="./index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                <a href="./index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                <a href="./index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                    Contact Us
-                </a>
-            </div>
-        </div>
-    </div>
-</nav>
+  {% include navbar.html %}
   <header class="masthead">
     <div class="masthead-inner">
       <div class="masthead-label">EternaX Research | Post-Quantum Financial Infrastructure</div>

--- a/blogs/3-trillion-must-migrate/index.html
+++ b/blogs/3-trillion-must-migrate/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/blogs/all-in-one-signature-that-built-bitcoin/index.html
+++ b/blogs/all-in-one-signature-that-built-bitcoin/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/blogs/dr-chen-feng-chief-scientist/index.html
+++ b/blogs/dr-chen-feng-chief-scientist/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -468,109 +470,7 @@
 <body class="font-sans">
 
   <!-- NAV -->
-  <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between items-center py-2">
-            <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-            <!-- Desktop nav -->
-            <div class="hidden md:flex items-center space-x-6">
-                <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                <div class="relative group">
-                    <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </span>
-                    <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                        <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                            </a>
-                            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                            </a>
-                            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                            </a>
-                        </div>
-                    </div>
-                </div>
-                <div class="relative group">
-                    <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </span>
-                    <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                        <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                            <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                            </a>
-                            <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                            </a>
-                            <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                            </a>
-                            <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                            </a>
-                            <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                            </a>
-                        </div>
-                    </div>
-                </div>
-                <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                    Contact Us
-                </a>
-            </div>
-            <!-- Mobile hamburger -->
-            <div class="md:hidden">
-                <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                    <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                        <path d="M3 6h18M3 12h18M3 18h18" />
-                    </svg>
-                    <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                        <path d="M6 6l12 12M6 18L18 6" />
-                    </svg>
-                </button>
-            </div>
-        </div>
-        <!-- Mobile menu -->
-        <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-            <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-        <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-        <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-        <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                    Contact Us
-                </a>
-            </div>
-        </div>
-    </div>
-</nav>
+  {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body blog-body--longform">

--- a/blogs/hiding-your-public-key-wont-save-your-coins/index.html
+++ b/blogs/hiding-your-public-key-wont-save-your-coins/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -215,112 +217,7 @@
 </head>
 <body class="font-sans" itemscope itemtype="https://schema.org/WebPage">
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <div class="flex items-center">
-                    <a href="../index.html" class="text-xl font-bold" style="color: var(--fg);">eternaX</a>
-                </div>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="#" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-                    <a href="post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-                    <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-                    <a href="already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="#" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16">
         <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/blogs/migrate-later-is-a-stablecoin-liquidity-risk/index.html
+++ b/blogs/migrate-later-is-a-stablecoin-liquidity-risk/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/blogs/mint-new-dollars-onchain-on-a-post-quantum-settlement-rail/index.html
+++ b/blogs/mint-new-dollars-onchain-on-a-post-quantum-settlement-rail/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/blogs/occ-did-not-kill-stablecoins/index.html
+++ b/blogs/occ-did-not-kill-stablecoins/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/blogs/post-quantum-is-not-enough/index.html
+++ b/blogs/post-quantum-is-not-enough/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/blogs/private-chains-are-not-private/index.html
+++ b/blogs/private-chains-are-not-private/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/blogs/quantum-risk-is-a-cost-curve/index.html
+++ b/blogs/quantum-risk-is-a-cost-curve/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/blogs/right-to-cryptography/index.html
+++ b/blogs/right-to-cryptography/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/blogs/silmarils-post-quantum-authentication-without-size-tax/index.html
+++ b/blogs/silmarils-post-quantum-authentication-without-size-tax/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -164,109 +166,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/blogs/silmarils-post-quantum-authentication-without-size-tax/index.md
+++ b/blogs/silmarils-post-quantum-authentication-without-size-tax/index.md
@@ -1,7 +1,3 @@
----
-title: "SILMARILS: Compact Post-Quantum Authentication for Blockchain Systems"
-description: "How the SILMARILS designated-verifier signature construction gives EternaX a compact authentication layer for post-quantum, high-throughput blockchain infrastructure."
----
 # SILMARILS: Compact Post-Quantum Authentication for Blockchain Systems 
 
 ![Abstract post-quantum authentication architecture for SILMARILS](Hero_Image.png)

--- a/blogs/the-real-migration-is-bigger-than-quantum/index.html
+++ b/blogs/the-real-migration-is-bigger-than-quantum/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="../../index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/glossary.html
+++ b/glossary.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -361,112 +363,7 @@
 </head>
 <body class="font-sans" itemscope itemtype="https://schema.org/WebPage">
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <div class="flex items-center">
-                    <a href="./index.html" class="text-xl font-bold" style="color: var(--fg);">eternaX</a>
-                </div>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="./why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="./post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="./post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="./already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="./index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="./index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="./index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="./index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="./index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="./index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="blogs/index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="./why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-                    <a href="./post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-                    <a href="./post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-                    <a href="./already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <a href="blogs/index.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="./index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="./index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="./index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="./index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="./index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="./index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <!-- PAGE CONTENT STARTS HERE -->
     <main class="pt-20">

--- a/index.html
+++ b/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -251,113 +253,7 @@
 </head>
 <body class="font-sans" itemscope itemtype="https://schema.org/WebPage">
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <div class="flex items-center">
-                    <!-- <img src="./assets/eternax-logo.svg" alt="eternaX Logo" class="w-8 h-8 mr-3"> -->
-                    <span class="text-xl font-bold">eternaX</span>
-                </div>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="blogs/index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-                    <a href="post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-                    <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-                    <a href="already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <a href="blogs/index.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
     <main id="main-content">
     <!-- Hero Section -->
     <section class="flex items-center justify-center relative overflow-hidden pt-32 lg:pt-40 pb-12 lg:pb-16" itemscope itemtype="https://schema.org/WebPageElement" itemprop="mainContentOfPage">

--- a/page-template.html
+++ b/page-template.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -193,106 +195,7 @@
 </head>
 <body class="font-sans" itemscope itemtype="https://schema.org/WebPage">
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <div class="flex items-center">
-                    <a href="../index.html" class="text-xl font-bold" style="color: var(--fg);">eternaX</a>
-                </div>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="blogs/index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <!-- PAGE CONTENT STARTS HERE -->
     <!-- Add your page-specific content below -->

--- a/post-quantum-cryptography-risk-framework-for-institutions.html
+++ b/post-quantum-cryptography-risk-framework-for-institutions.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en" prefix="og: https://ogp.me/ns#">
 <head>
@@ -783,111 +785,7 @@ summary.faq-q:hover{color:var(--navy-hover)}
 <body>
 
 <!-- ═══ NAVIGATION -->
-<nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="flex justify-between items-center py-2">
-          <div class="flex items-center">
-              <a href="./index.html" class="text-xl font-bold" style="color: var(--fg);">eternaX</a>
-          </div>
-          <!-- Desktop nav -->
-          <div class="hidden md:flex items-center space-x-6">
-            <a href="./why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-            <div class="relative group">
-              <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-              </span>
-              <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                  <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                      <a href="post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                          <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                          <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                      </a>
-                      <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                          <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                          <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                      </a>
-                      <a href="already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                          <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                          <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                      </a>
-                  </div>
-              </div>
-          </div>
-              <div class="relative group">
-                  <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                  </span>
-                  <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                      <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                          <a href="./index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                              <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                              <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                          </a>
-                          <a href="./index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                              <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                              <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                              <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                              <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                          </a>
-                          <a href="./index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                              <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                              <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                              <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                              <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                          </a>
-                          <a href="./index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                              <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                              <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                          </a>
-                          <a href="./index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                              <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                              <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                              <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                              <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                          </a>
-                      </div>
-                  </div>
-              </div>
-              <a href="./index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-              <a href="blogs/index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-              <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                  Contact Us
-              </a>
-          </div>
-          <!-- Mobile hamburger -->
-          <div class="md:hidden">
-              <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                  <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                      <path d="M3 6h18M3 12h18M3 18h18" />
-                  </svg>
-                  <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                      <path d="M6 6l12 12M6 18L18 6" />
-                  </svg>
-              </button>
-          </div>
-      </div>
-      <!-- Mobile menu -->
-      <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-          <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-            <a href="why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-            <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-              <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-              <a href="./index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-              <a href="./index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-              <a href="./index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-              <a href="./index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-              <a href="./index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-              <a href="./index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-              <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                  Contact Us
-              </a>
-          </div>
-      </div>
-  </div>
-</nav>
+{% include navbar.html %}
 
 <!-- ═══ COVER -->
 <header class="cover" role="banner">

--- a/post-quantum-signature-security-ranking-2026.html
+++ b/post-quantum-signature-security-ranking-2026.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -229,7 +231,14 @@
         }
         .site-nav a:hover { color: var(--white); }
 
-        nav { font-family: ui-sans-serif, system-ui, sans-serif; }
+        nav {
+            font-family: ui-sans-serif, system-ui, sans-serif;
+            --fg-70: var(--fg);
+            --fg-80: var(--fg);
+        }
+        nav.glass-effect {
+            border: 1px solid var(--border);
+        }
         .glass-effect {
             background: #ffffff;
             border: 1px solid var(--border-light);
@@ -844,111 +853,7 @@
 <a href="#main-content" style="position:absolute;left:-9999px;top:0;padding:8px 16px;background:var(--green);color:white;font-family:'IBM Plex Sans',sans-serif;font-size:0.85rem;z-index:9999;text-decoration:none;" onfocus="this.style.left='0'" onblur="this.style.left='-9999px'">Skip to content</a>
 
 <!-- Navigation -->
-<nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between items-center py-2">
-            <div class="flex items-center">
-                <a href="./index.html" class="text-xl font-bold" style="color: var(--fg);">eternaX</a>
-            </div>
-            <!-- Desktop nav -->
-            <div class="hidden md:flex items-center space-x-6">
-                <a href="./why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                <div class="relative group">
-                    <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </span>
-                    <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                        <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                            <a href="post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                            </a>
-                            <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                            </a>
-                            <a href="already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                            </a>
-                        </div>
-                    </div>
-                </div>
-                <div class="relative group">
-                    <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </span>
-                    <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                        <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                            <a href="./index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                            </a>
-                            <a href="./index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                            </a>
-                            <a href="./index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                            </a>
-                            <a href="./index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                            </a>
-                            <a href="./index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                            </a>
-                        </div>
-                    </div>
-                </div>
-                <a href="./index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                <a href="blogs/index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                    Contact Us
-                </a>
-            </div>
-            <!-- Mobile hamburger -->
-            <div class="md:hidden">
-                <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                    <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                        <path d="M3 6h18M3 12h18M3 18h18" />
-                    </svg>
-                    <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                        <path d="M6 6l12 12M6 18L18 6" />
-                    </svg>
-                </button>
-            </div>
-        </div>
-        <!-- Mobile menu -->
-        <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-            <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                <a href="why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-                <a href="post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-                <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-                <a href="already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                <a href="./index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                <a href="./index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                <a href="./index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                <a href="./index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                <a href="./index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                <a href="./index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                    Contact Us
-                </a>
-            </div>
-        </div>
-    </div>
-</nav>
+{% include navbar.html %}
 
 <main id="main-content">
 <div class="article-container">

--- a/scripts/blog-template.html
+++ b/scripts/blog-template.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -163,109 +165,7 @@
     </script>
 </head>
 <body class="font-sans">
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <a href="{{base}}index.html" class="text-xl font-bold" style="color: var(--fg)">eternaX</a>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="../../why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="../../index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="../../index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="../../index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="../../index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="../../index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="../../index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="../index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="../../why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-            <a href="../../post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-            <a href="../../post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-            <a href="../../already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="../../index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="../../index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="../../index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="../../index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="../../index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="../../index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <main class="pt-24 pb-16 px-4">
         <article class="blog-body">

--- a/why-eternax.html
+++ b/why-eternax.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1120,112 +1122,7 @@ body {
 </head>
 <body class="font-sans" itemscope itemtype="https://schema.org/WebPage">
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 glass-effect border-b" style="background: rgba(255, 255, 255, 0.5); backdrop-filter: blur(10px);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-2">
-                <div class="flex items-center">
-                    <a href="./index.html" class="text-xl font-bold" style="color: var(--fg);">eternaX</a>
-                </div>
-                <!-- Desktop nav -->
-                <div class="hidden md:flex items-center space-x-6">
-                    <a href="./why-eternax.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Quantum Risk Reports
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="post-quantum-signature-security-ranking-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
-                                </a>
-                                <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Cryptographic Migration Debt Framework</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">April 2026 · Post-quantum exposure framework for institutional digital asset programmes.</span>
-                                </a>
-                                <a href="already-broken-quantum-risk-report-q1-2026.html" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Already Broken — Quantum Risk Report Q1 2026</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Q1 2026 · The case that institutional blockchain infrastructure is already at risk.</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="relative group">
-                        <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                        </span>
-                        <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                            <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                                <a href="index.html#product-settlement" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                                </a>
-                                <a href="index.html#product-issuance" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                                </a>
-                                <a href="index.html#product-migration" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                                </a>
-                                <a href="index.html#product-wallet" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                                </a>
-                                <a href="index.html#product-venues" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                    <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                    <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="./index.html#team" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="blogs/index.html" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-                <!-- Mobile hamburger -->
-                <div class="md:hidden">
-                    <button id="mobile-menu-button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2" style="color: var(--fg-70); border-color: var(--border)">
-                        <svg id="icon-menu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-                            <path d="M3 6h18M3 12h18M3 18h18" />
-                        </svg>
-                        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6 hidden">
-                            <path d="M6 6l12 12M6 18L18 6" />
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <!-- Mobile menu -->
-            <div id="mobile-menu" class="md:hidden hidden pb-4" role="dialog" aria-modal="true">
-                <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
-                    <a href="why-eternax.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
-                    <a href="post-quantum-signature-security-ranking-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
-                    <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
-                    <a href="already-broken-quantum-risk-report-q1-2026.html" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
-                    <a href="blogs/index.html" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                    <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                    <a href="index.html#product-settlement" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                    <a href="index.html#product-issuance" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                    <a href="index.html#product-migration" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                    <a href="index.html#product-wallet" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                    <a href="index.html#product-venues" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
-                    <a href="./index.html#team" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
-                    <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
-                        Contact Us
-                    </a>
-                </div>
-            </div>
-        </div>
-    </nav>
+    {% include navbar.html %}
 
     <!-- Page Content -->
     <main class="pt-20">


### PR DESCRIPTION
## Summary
- extract duplicated navbar markup into `_includes/navbar.html` and replace page-level nav blocks with `{% include navbar.html %}` across root pages, blog pages, and templates
- make navbar links GitHub Pages-safe with `relative_url`, add Jekyll front matter where needed, and fix the Silmarils `index.md` front-matter conflict that caused duplicate output paths
- ignore Jekyll build artifacts and update `.github/workflows/deploy.yml` to use the official GitHub Pages Jekyll build/deploy actions pipeline

## Test plan
- [x] Run local Jekyll preview and verify shared navbar renders on home, report, and blog pages
- [x] Confirm no destination conflict for `blogs/silmarils-post-quantum-authentication-without-size-tax/index.html`
- [x] Verify navbar styling parity on `post-quantum-signature-security-ranking-2026.html`
- [x] Confirm workflow now builds Jekyll output before deploy