### PR TITLE
Fix blog rendering conflict in Pages Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+exclude:
+  - blogs/*/index.md


### PR DESCRIPTION
## Summary
- add `_config.yml` to exclude `blogs/*/index.md` from Jekyll processing on GitHub Pages
- prevent output path collisions between source markdown files and hand-authored `blogs/*/index.html` pages
- restore correct deployed layout for blog pages after switching to official Pages Jekyll workflow

## Test plan
- [x] Verify `_config.yml` excludes `blogs/*/index.md`
- [x] Confirm branch pushed with hotfix commit
- [ ] Wait for Pages workflow run and verify affected blog pages render with expected HTML layout