### PR TITLE
Add institutional exposure map report and align risk labeling

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -11,7 +11,11 @@
                     </span>
                     <div class="nav-products-dropdown absolute left-0 top-full pt-1">
                         <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                            <a href="{{ '/post-quantum-signature-security-ranking-2026.html' | relative_url }}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
+                            <a href="{{ '/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html' | relative_url }}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
+                                <span class="font-semibold text-sm block">Post-Quantum Exposure Map 2026</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Institutional exposure map for tokenized assets, stablecoins, RWAs, collateral, and privacy.</span>
+                            </a>
+                            <a href="{{ '/post-quantum-signature-security-ranking-2026.html' | relative_url }}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
                                 <span class="font-semibold text-sm block">Post-Quantum Signature Security Ranking 2026</span>
                                 <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Comparative ranking of NIST post-quantum signature schemes for institutional deployment.</span>
                             </a>
@@ -84,6 +88,7 @@
             <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
                 <a href="{{ '/why-eternax.html' | relative_url }}" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
                 <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
+                <a href="{{ '/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Exposure Map 2026 <span class="text-xs opacity-60">May 2026</span></a>
                 <a href="{{ '/post-quantum-signature-security-ranking-2026.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
                 <a href="{{ '/post-quantum-cryptography-risk-framework-for-institutions.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
                 <a href="{{ '/already-broken-quantum-risk-report-q1-2026.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>

--- a/post-quantum-signature-security-ranking-2026.html
+++ b/post-quantum-signature-security-ranking-2026.html
@@ -236,12 +236,9 @@
             --fg-70: var(--fg);
             --fg-80: var(--fg);
         }
-        nav.glass-effect {
-            border: 1px solid var(--border);
-        }
         .glass-effect {
             background: #ffffff;
-            border: 1px solid var(--border-light);
+            border: 1px solid var(--border);
             box-shadow: 0 1px 3px rgba(0,0,0,0.06);
         }
         .link-muted {
@@ -252,8 +249,9 @@
         .btn-primary {
             background-color: var(--fg);
             transition: background-color 0.15s;
+            color: #fff;
         }
-        .btn-primary:hover { background-color: var(--navy-deep); }
+        .btn-primary:hover { background-color: var(--navy-light); }
         .nav-products-dropdown {
             opacity: 0;
             visibility: hidden;
@@ -263,6 +261,11 @@
             opacity: 1;
             visibility: visible;
         }
+        /* Normalize shared navbar size on this page (base html font-size is 17px here). */
+        nav .text-xl { font-size: 20px; line-height: 28px; }
+        nav .text-sm { font-size: 14px; line-height: 20px; }
+        nav .text-xs { font-size: 12px; line-height: 16px; }
+        nav .py-2 { padding-top: 8px; padding-bottom: 8px; }
 
         /* === LAYOUT === */
         .article-container { max-width: 780px; margin: 0 auto; padding: 0 24px; }

--- a/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html
+++ b/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html
@@ -441,6 +441,8 @@ tbody tr:last-child td { border-bottom: none; }
 .risk-5 { color: var(--red); font-weight: 700; }
 .risk-4 { color: #9c4a1a; font-weight: 600; }
 .risk-3 { color: #7c6a1f; font-weight: 600; }
+.risk-2 { color: #2f5e52; font-weight: 600; }
+.risk-1 { color: #2f7a68; font-weight: 600; }
 
 /* CALLOUT BLOCKS */
 .callout {
@@ -630,8 +632,9 @@ tbody tr:last-child td { border-bottom: none; }
 }
 .inst-card-header {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: flex-start;
+  gap: 0.35rem;
   margin-bottom: 0.6rem;
 }
 .inst-card-name {
@@ -665,9 +668,12 @@ tbody tr:last-child td { border-bottom: none; }
   border-radius: 3px;
   margin-left: 0.25rem;
 }
+.inst-card-header .risk-badge { margin-left: 0; }
 .risk-badge-5 { background: var(--red); color: #fff; }
 .risk-badge-4 { background: #9c4a1a; color: #fff; }
 .risk-badge-3 { background: #7c6a1f; color: #fff; }
+.risk-badge-2 { background: #2f5e52; color: #fff; }
+.risk-badge-1 { background: #2f7a68; color: #fff; }
 
 /* SECTION DIVIDER */
 .section-divider {
@@ -1125,33 +1131,33 @@ tbody tr:last-child td { border-bottom: none; }
 <div class="table-wrap">
 <table class="compact-table">
 <thead>
-<tr><th>Institution</th><th>Product</th><th>Value</th><th>Chain</th><th>Q Risk</th><th>Verdict</th></tr>
+<tr><th>Institution</th><th>Product</th><th>Value</th><th>Chain</th><th>Quantum Risk</th><th>Verdict</th></tr>
 </thead>
 <tbody>
-<tr><td class="inst-name">BlackRock / Securitize</td><td>BUIDL</td><td>~$2.5B</td><td>Ethereum, multichain</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Largest single PQ dependency cluster. Reserve asset for OUSG, USDtb.</td></tr>
-<tr><td class="inst-name">Circle / Hashnote</td><td>USYC</td><td>$313M</td><td>Base, Canton, Ethereum, NEAR, Solana</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Five-chain exposure. Two-token model amplifies bridge and oracle risk.</td></tr>
-<tr><td class="inst-name">Franklin Templeton</td><td>BENJI / FOBXX</td><td>$825M</td><td>9 chains: Stellar, Polygon, Arbitrum, Avalanche, Aptos, Base, Ethereum, Solana, BNB</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Nine public chains. Ed25519 + secp256k1. Centralized TA override.</td></tr>
-<tr><td class="inst-name">Franklin Templeton</td><td>iBENJI</td><td>$1.56B</td><td>Public blockchain</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Largest Franklin product. Chain-specific risk not fully disclosed.</td></tr>
-<tr><td class="inst-name">WisdomTree</td><td>WTGXX</td><td>$951M</td><td>Stellar, Ethereum</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Ed25519 + secp256k1. Migration requires fund admin coordination.</td></tr>
-<tr><td class="inst-name">Superstate</td><td>USTB + USCC</td><td>$988M + $269M</td><td>Ethereum, Solana, Plume</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Regulated fund integrated into DeFi lending. Compounds issuance + lending risk.</td></tr>
-<tr><td class="inst-name">Ondo</td><td>OUSG / USDY</td><td>Backed by BUIDL</td><td>Ethereum, XRPL</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Stacked tokenization: OUSG backed by BUIDL, used as sole collateral on Flux.</td></tr>
-<tr><td class="inst-name">VanEck / Securitize</td><td>VBILL</td><td>$59M</td><td>Securitize multichain, Wormhole</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Bridge-first risk. Wormhole attestation is the weakest link.</td></tr>
-<tr><td class="inst-name">Janus Henderson</td><td>JTRSY</td><td>$970M</td><td>Centrifuge, LayerZero</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Bridge-layer risk via LayerZero cross-chain expansion.</td></tr>
-<tr><td class="inst-name">Apollo / Securitize</td><td>ACRED</td><td>Not disclosed</td><td>6 chains: Aptos, Avalanche, Ethereum, Ink, Polygon, Solana</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Six-chain exposure. Leveraged RWA strategy on Morpho.</td></tr>
-<tr><td class="inst-name">UBS</td><td>uMINT</td><td>Not disclosed</td><td>Ethereum</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>G-SIB on public chain. Bank-grade migration coordination required.</td></tr>
-<tr><td class="inst-name">SG-FORGE</td><td>EURCV</td><td>Not disclosed</td><td>Ethereum, Solana, XRPL, Stellar</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>MiCA stablecoin on four vulnerable chains.</td></tr>
-<tr><td class="inst-name">State Street / Galaxy</td><td>SWEEP</td><td>Launching May 2026</td><td>Solana, Stellar, Ethereum planned</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Brand-new product on rails with 90% PQ throughput loss.</td></tr>
-<tr><td class="inst-name">Ripple</td><td>RLUSD</td><td>Live</td><td>XRPL, Ethereum, Wormhole NTT</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Stablecoin + prime brokerage + bridge expansion.</td></tr>
-<tr><td class="inst-name">PayPal / Paxos</td><td>PYUSD</td><td>Live</td><td>Ethereum, Solana, Arbitrum</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Consumer stablecoin on classical rails.</td></tr>
-<tr><td class="inst-name">Anchorage</td><td>USDtb reserves</td><td>Reserves in BUIDL</td><td>Bank + BUIDL chain</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Stacked: stablecoin admin keys on top of BUIDL reserve dependency.</td></tr>
-<tr><td class="inst-name">J.P. Morgan</td><td>Kinexys</td><td>&gt;$1.5T processed</td><td>Private DLT</td><td><span class="risk-badge risk-badge-3">3/5</span></td><td>Not public-chain theft. Control-plane and KMS migration risk.</td></tr>
-<tr><td class="inst-name">Goldman / BNY</td><td>GS DAP mirrors</td><td>Not disclosed</td><td>Private permissioned</td><td><span class="risk-badge risk-badge-3">3/5</span></td><td>Heaviest migration/legal debt. Opacity in cryptographic stack.</td></tr>
-<tr><td class="inst-name">Std Chartered / OKX</td><td>BUIDL collateral</td><td>Not disclosed</td><td>Off-exchange custody</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>First G-SIB-backed tokenized collateral. Concentrated admin keys.</td></tr>
-<tr><td class="inst-name">Binance / Ceffu</td><td>BUIDL off-exchange</td><td>Not disclosed</td><td>Off-exchange, BNB Chain</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Off-exchange custody keys on classical rails.</td></tr>
-<tr><td class="inst-name">Deribit</td><td>USYC margin</td><td>Not disclosed</td><td>Venue system</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Yield-bearing derivatives collateral. Haircut widening risk.</td></tr>
-<tr><td class="inst-name">DTCC</td><td>Collateral AppChain</td><td>Pilot Q4 2026</td><td>AppChain</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Pilot on vulnerable rails becomes production default.</td></tr>
-<tr><td class="inst-name">Broadridge</td><td>DLT Repo</td><td>$362B ADV</td><td>DLT / Canton</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Hundreds of billions daily. Migration debt at infrastructure scale.</td></tr>
-<tr><td class="inst-name">Aave</td><td>Horizon RWA</td><td>TVL $604M</td><td>Ethereum</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Oracle/NAV risk. Liquidation on public chain. Permissioned collateral, public rails.</td></tr>
+<tr><td class="inst-name">BlackRock / Securitize</td><td>BUIDL</td><td>~$2.5B</td><td>Ethereum, multichain</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>Largest single PQ dependency cluster. Reserve asset for OUSG, USDtb.</td></tr>
+<tr><td class="inst-name">Circle / Hashnote</td><td>USYC</td><td>$313M</td><td>Base, Canton, Ethereum, NEAR, Solana</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>Five-chain exposure. Two-token model amplifies bridge and oracle risk.</td></tr>
+<tr><td class="inst-name">Franklin Templeton</td><td>BENJI / FOBXX</td><td>$825M</td><td>9 chains: Stellar, Polygon, Arbitrum, Avalanche, Aptos, Base, Ethereum, Solana, BNB</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>Nine public chains. Ed25519 + secp256k1. Centralized TA override.</td></tr>
+<tr><td class="inst-name">Franklin Templeton</td><td>iBENJI</td><td>$1.56B</td><td>Public blockchain</td><td><span class="risk-badge risk-badge-4">Critical Quantum Risk 4/5</span></td><td>Largest Franklin product. Chain-specific risk not fully disclosed.</td></tr>
+<tr><td class="inst-name">WisdomTree</td><td>WTGXX</td><td>$951M</td><td>Stellar, Ethereum</td><td><span class="risk-badge risk-badge-4">Critical Quantum Risk 4/5</span></td><td>Ed25519 + secp256k1. Migration requires fund admin coordination.</td></tr>
+<tr><td class="inst-name">Superstate</td><td>USTB + USCC</td><td>$988M + $269M</td><td>Ethereum, Solana, Plume</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>Regulated fund integrated into DeFi lending. Compounds issuance + lending risk.</td></tr>
+<tr><td class="inst-name">Ondo</td><td>OUSG / USDY</td><td>Backed by BUIDL</td><td>Ethereum, XRPL</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>Stacked tokenization: OUSG backed by BUIDL, used as sole collateral on Flux.</td></tr>
+<tr><td class="inst-name">VanEck / Securitize</td><td>VBILL</td><td>$59M</td><td>Securitize multichain, Wormhole</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>Bridge-first risk. Wormhole attestation is the weakest link.</td></tr>
+<tr><td class="inst-name">Janus Henderson</td><td>JTRSY</td><td>$970M</td><td>Centrifuge, LayerZero</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>Bridge-layer risk via LayerZero cross-chain expansion.</td></tr>
+<tr><td class="inst-name">Apollo / Securitize</td><td>ACRED</td><td>Not disclosed</td><td>6 chains: Aptos, Avalanche, Ethereum, Ink, Polygon, Solana</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>Six-chain exposure. Leveraged RWA strategy on Morpho.</td></tr>
+<tr><td class="inst-name">UBS</td><td>uMINT</td><td>Not disclosed</td><td>Ethereum</td><td><span class="risk-badge risk-badge-4">Critical Quantum Risk 4/5</span></td><td>G-SIB on public chain. Bank-grade migration coordination required.</td></tr>
+<tr><td class="inst-name">SG-FORGE</td><td>EURCV</td><td>Not disclosed</td><td>Ethereum, Solana, XRPL, Stellar</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>MiCA stablecoin on four vulnerable chains.</td></tr>
+<tr><td class="inst-name">State Street / Galaxy</td><td>SWEEP</td><td>Launching May 2026</td><td>Solana, Stellar, Ethereum planned</td><td><span class="risk-badge risk-badge-4">Critical Quantum Risk 4/5</span></td><td>Brand-new product on rails with 90% PQ throughput loss.</td></tr>
+<tr><td class="inst-name">Ripple</td><td>RLUSD</td><td>Live</td><td>XRPL, Ethereum, Wormhole NTT</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>Stablecoin + prime brokerage + bridge expansion.</td></tr>
+<tr><td class="inst-name">PayPal / Paxos</td><td>PYUSD</td><td>Live</td><td>Ethereum, Solana, Arbitrum</td><td><span class="risk-badge risk-badge-4">Critical Quantum Risk 4/5</span></td><td>Consumer stablecoin on classical rails.</td></tr>
+<tr><td class="inst-name">Anchorage</td><td>USDtb reserves</td><td>Reserves in BUIDL</td><td>Bank + BUIDL chain</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>Stacked: stablecoin admin keys on top of BUIDL reserve dependency.</td></tr>
+<tr><td class="inst-name">J.P. Morgan</td><td>Kinexys</td><td>&gt;$1.5T processed</td><td>Private DLT</td><td><span class="risk-badge risk-badge-3">High Quantum Risk 3/5</span></td><td>Not public-chain theft. Control-plane and KMS migration risk.</td></tr>
+<tr><td class="inst-name">Goldman / BNY</td><td>GS DAP mirrors</td><td>Not disclosed</td><td>Private permissioned</td><td><span class="risk-badge risk-badge-3">High Quantum Risk 3/5</span></td><td>Heaviest migration/legal debt. Opacity in cryptographic stack.</td></tr>
+<tr><td class="inst-name">Std Chartered / OKX</td><td>BUIDL collateral</td><td>Not disclosed</td><td>Off-exchange custody</td><td><span class="risk-badge risk-badge-4">Critical Quantum Risk 4/5</span></td><td>First G-SIB-backed tokenized collateral. Concentrated admin keys.</td></tr>
+<tr><td class="inst-name">Binance / Ceffu</td><td>BUIDL off-exchange</td><td>Not disclosed</td><td>Off-exchange, BNB Chain</td><td><span class="risk-badge risk-badge-4">Critical Quantum Risk 4/5</span></td><td>Off-exchange custody keys on classical rails.</td></tr>
+<tr><td class="inst-name">Deribit</td><td>USYC margin</td><td>Not disclosed</td><td>Venue system</td><td><span class="risk-badge risk-badge-4">Critical Quantum Risk 4/5</span></td><td>Yield-bearing derivatives collateral. Haircut widening risk.</td></tr>
+<tr><td class="inst-name">DTCC</td><td>Collateral AppChain</td><td>Pilot Q4 2026</td><td>AppChain</td><td><span class="risk-badge risk-badge-4">Critical Quantum Risk 4/5</span></td><td>Pilot on vulnerable rails becomes production default.</td></tr>
+<tr><td class="inst-name">Broadridge</td><td>DLT Repo</td><td>$362B ADV</td><td>DLT / Canton</td><td><span class="risk-badge risk-badge-4">Critical Quantum Risk 4/5</span></td><td>Hundreds of billions daily. Migration debt at infrastructure scale.</td></tr>
+<tr><td class="inst-name">Aave</td><td>Horizon RWA</td><td>TVL $604M</td><td>Ethereum</td><td><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></td><td>Oracle/NAV risk. Liquidation on public chain. Permissioned collateral, public rails.</td></tr>
 </tbody>
 </table>
 </div>
@@ -1160,56 +1166,56 @@ tbody tr:last-child td { border-bottom: none; }
 <div class="inst-grid">
 
 <div class="inst-card">
-<div class="inst-card-header"><span class="inst-card-name">BlackRock / Securitize</span><span class="risk-badge risk-badge-5">PQ 5/5</span></div>
+<div class="inst-card-header"><span class="inst-card-name">BlackRock / Securitize</span><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></div>
 <div class="inst-card-product">BUIDL tokenized Treasury/MMF &middot; ~$2.5B</div>
 <div class="inst-card-meta"><strong>Chain:</strong> Ethereum + multichain via Securitize &middot; <strong>Primitives:</strong> secp256k1 &middot; <strong>Partners:</strong> OKX, Binance, Hidden Road, Komainu, Ondo, Anchorage</div>
 <div class="inst-card-risk"><strong>Why exposed:</strong> Concentrated admin/TA keys at Securitize control mint, burn, whitelist across all share classes. Downstream reserve asset for OUSG and USDtb means a control-plane compromise propagates across products and venues. No PQ migration disclosed. <strong>New issuance:</strong> Future share classes should evaluate PQ-native rails.</div>
 </div>
 
 <div class="inst-card">
-<div class="inst-card-header"><span class="inst-card-name">Circle / Hashnote</span><span class="risk-badge risk-badge-5">PQ 5/5</span></div>
+<div class="inst-card-header"><span class="inst-card-name">Circle / Hashnote</span><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></div>
 <div class="inst-card-product">USYC tokenized MMF &middot; $313M</div>
 <div class="inst-card-meta"><strong>Chain:</strong> Base, Canton, Ethereum, NEAR, Solana &middot; <strong>Primitives:</strong> secp256k1, Ed25519 &middot; <strong>Collateral:</strong> Deribit cross-margin</div>
 <div class="inst-card-risk"><strong>Why exposed:</strong> Five chains, each using classical signatures. Two-token model (USYC + USDC redemption) creates interoperability dependencies on Circle attestation services. <strong>New issuance:</strong> New collateral rails and chain expansions should be PQ-native.</div>
 </div>
 
 <div class="inst-card">
-<div class="inst-card-header"><span class="inst-card-name">Franklin Templeton</span><span class="risk-badge risk-badge-5">PQ 5/5</span></div>
+<div class="inst-card-header"><span class="inst-card-name">Franklin Templeton</span><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></div>
 <div class="inst-card-product">BENJI / FOBXX &middot; $825M</div>
 <div class="inst-card-meta"><strong>Chain:</strong> 9 networks (Stellar, Polygon, Arbitrum, Avalanche, Aptos, Base, Ethereum, Solana, BNB) &middot; <strong>Primitives:</strong> Ed25519, secp256k1</div>
 <div class="inst-card-risk"><strong>Why exposed:</strong> Transfer agent maintains centralized override across nine public chains. Each new chain deployment compounds migration debt. Textbook case of public-chain contact + centralized administrative control. <strong>New issuance:</strong> Treat each chain expansion as a new issuance decision.</div>
 </div>
 
 <div class="inst-card">
-<div class="inst-card-header"><span class="inst-card-name">Ondo</span><span class="risk-badge risk-badge-5">PQ 5/5</span></div>
+<div class="inst-card-header"><span class="inst-card-name">Ondo</span><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></div>
 <div class="inst-card-product">OUSG / Flux &middot; Backed by BUIDL</div>
 <div class="inst-card-meta"><strong>Chain:</strong> Ethereum, XRPL &middot; <strong>Primitives:</strong> secp256k1, Ed25519 &middot; <strong>Collateral:</strong> Sole collateral on Flux</div>
 <div class="inst-card-risk"><strong>Why exposed:</strong> Stacked tokenization: OUSG is backed by BUIDL, then used as sole collateral on Flux. One classical control-plane layer secures another. Breaking the base layer breaks the borrowing layer. <strong>New issuance:</strong> Stacked tokenization demands PQ-native rails at the base.</div>
 </div>
 
 <div class="inst-card">
-<div class="inst-card-header"><span class="inst-card-name">Superstate</span><span class="risk-badge risk-badge-5">PQ 5/5</span></div>
+<div class="inst-card-header"><span class="inst-card-name">Superstate</span><span class="risk-badge risk-badge-5">Highly Critical Quantum Risk 5/5</span></div>
 <div class="inst-card-product">USTB ($988M) + USCC ($269M)</div>
 <div class="inst-card-meta"><strong>Chain:</strong> Ethereum, Solana, Plume &middot; <strong>DeFi:</strong> Aave Horizon integration ($66.5M USTB)</div>
 <div class="inst-card-risk"><strong>Why exposed:</strong> Sits at the boundary of regulated fund and DeFi-collateral primitive. Combines public-chain issuance risk with onchain borrowing interface risk. <strong>New issuance:</strong> DeFi collateral integrations on classical rails multiply migration debt.</div>
 </div>
 
 <div class="inst-card">
-<div class="inst-card-header"><span class="inst-card-name">J.P. Morgan</span><span class="risk-badge risk-badge-3">PQ 3/5</span></div>
+<div class="inst-card-header"><span class="inst-card-name">J.P. Morgan</span><span class="risk-badge risk-badge-3">High Quantum Risk 3/5</span></div>
 <div class="inst-card-product">Kinexys &middot; &gt;$1.5T processed</div>
 <div class="inst-card-meta"><strong>Chain:</strong> Private bank-led DLT &middot; <strong>Primitives:</strong> Classical enterprise crypto (not disclosed)</div>
 <div class="inst-card-risk"><strong>Why exposed:</strong> Not public-chain theft risk. Control-plane-heavy: bank admin keys, KMS, legal continuity across tokenized deposits, GBP blockchain accounts, and interoperability. <strong>New issuance:</strong> New settlement corridors should test PQ-native rails.</div>
 </div>
 
 <div class="inst-card">
-<div class="inst-card-header"><span class="inst-card-name">Goldman / BNY</span><span class="risk-badge risk-badge-3">PQ 3/5</span></div>
+<div class="inst-card-header"><span class="inst-card-name">Goldman / BNY</span><span class="risk-badge risk-badge-3">High Quantum Risk 3/5</span></div>
 <div class="inst-card-product">GS DAP tokenized MMF mirrors</div>
 <div class="inst-card-meta"><strong>Chain:</strong> GS DAP private permissioned &middot; <strong>Partner:</strong> BNY Digital Assets</div>
 <div class="inst-card-risk"><strong>Why exposed:</strong> Private mirror ledger. Lower public-chain theft, but heaviest migration/legal debt: re-papering across banks, funds, client books, custody, and legacy systems. Exact crypto primitives not disclosed. <strong>New issuance:</strong> Private-ledger modernization can start with PQ-native pilots.</div>
 </div>
 
 <div class="inst-card">
-<div class="inst-card-header"><span class="inst-card-name">Std Chartered / OKX</span><span class="risk-badge risk-badge-4">PQ 4/5</span></div>
+<div class="inst-card-header"><span class="inst-card-name">Std Chartered / OKX</span><span class="risk-badge risk-badge-4">Critical Quantum Risk 4/5</span></div>
 <div class="inst-card-product">BUIDL yield-bearing collateral framework</div>
 <div class="inst-card-meta"><strong>Chain:</strong> Off-exchange SC custody, OKX venue &middot; <strong>Partners:</strong> BlackRock, Brevan Howard</div>
 <div class="inst-card-risk"><strong>Why exposed:</strong> First G-SIB-backed off-exchange tokenized collateral. Market choosing credit/legal structure first, composability second. Concentrated admin/custody keys and legal close-out complexity. <strong>New issuance:</strong> New collateral programs should test PQ-native custody and signing.</div>
@@ -1244,16 +1250,16 @@ tbody tr:last-child td { border-bottom: none; }
 <table>
 <thead><tr><th>Product Archetype</th><th>PQ Risk</th><th>Verdict</th></tr></thead>
 <tbody>
-<tr><td>Public-chain tokenized MMF on Ethereum/EVM</td><td><span class="risk-5">5/5</span></td><td>Full classical stack: wallet, admin, contract, consensus, bridge, oracle, collateral, migration. Highest combined exposure.</td></tr>
-<tr><td>Public-chain MMF on Solana/Stellar</td><td><span class="risk-4">4/5</span></td><td>Ed25519 quantum-vulnerable. Simpler contract surface than EVM, but admin concentration unchanged.</td></tr>
-<tr><td>Multichain fund with bridge layer</td><td><span class="risk-5">5/5</span></td><td>Bridge and messaging risk becomes first-order. Cross-chain attestation is the weakest link.</td></tr>
-<tr><td>Permissioned DeFi RWA lending</td><td><span class="risk-5">5/5</span></td><td>Liquidation depends on oracle/NAV freshness. Smart-contract risk plus permissioned collateral.</td></tr>
-<tr><td>CeFi off-exchange collateral / triparty</td><td><span class="risk-4">4/5</span></td><td>Lower base-chain code risk, but concentrated admin/custody keys and legal close-out complexity.</td></tr>
-<tr><td>Stablecoin backed by tokenized MMFs</td><td><span class="risk-5">5/5</span></td><td>Stacked dependency: stablecoin admin keys plus reserve-asset admin/oracle/bridge dependence.</td></tr>
-<tr><td>Private permissioned mirrors</td><td><span class="risk-3">3/5</span></td><td>Less public-holder theft, but concentrated operator/admin/KMS and legal migration debt dominate.</td></tr>
-<tr><td>Tokenized deposits / payments rails</td><td><span class="risk-3">3/5</span></td><td>Control-plane-heavy and dependent on KMS, bank admin keys, and legal continuity.</td></tr>
-<tr><td>Private DLT with selective privacy</td><td><span class="risk-3">3/5</span></td><td>PQ migration complicated by permissioned memberships, custom crypto stacks, contractual governance.</td></tr>
-<tr><td>Settlement / collateral infrastructure</td><td><span class="risk-4">4/5</span></td><td>Less about user wallets, more about institutional concentration and migration/legal debt at infrastructure scale.</td></tr>
+<tr><td>Public-chain tokenized MMF on Ethereum/EVM</td><td><span class="risk-5">Highly Critical Quantum Risk 5/5</span></td><td>Full classical stack: wallet, admin, contract, consensus, bridge, oracle, collateral, migration. Highest combined exposure.</td></tr>
+<tr><td>Public-chain MMF on Solana/Stellar</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Ed25519 quantum-vulnerable. Simpler contract surface than EVM, but admin concentration unchanged.</td></tr>
+<tr><td>Multichain fund with bridge layer</td><td><span class="risk-5">Highly Critical Quantum Risk 5/5</span></td><td>Bridge and messaging risk becomes first-order. Cross-chain attestation is the weakest link.</td></tr>
+<tr><td>Permissioned DeFi RWA lending</td><td><span class="risk-5">Highly Critical Quantum Risk 5/5</span></td><td>Liquidation depends on oracle/NAV freshness. Smart-contract risk plus permissioned collateral.</td></tr>
+<tr><td>CeFi off-exchange collateral / triparty</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Lower base-chain code risk, but concentrated admin/custody keys and legal close-out complexity.</td></tr>
+<tr><td>Stablecoin backed by tokenized MMFs</td><td><span class="risk-5">Highly Critical Quantum Risk 5/5</span></td><td>Stacked dependency: stablecoin admin keys plus reserve-asset admin/oracle/bridge dependence.</td></tr>
+<tr><td>Private permissioned mirrors</td><td><span class="risk-3">High Quantum Risk 3/5</span></td><td>Less public-holder theft, but concentrated operator/admin/KMS and legal migration debt dominate.</td></tr>
+<tr><td>Tokenized deposits / payments rails</td><td><span class="risk-3">High Quantum Risk 3/5</span></td><td>Control-plane-heavy and dependent on KMS, bank admin keys, and legal continuity.</td></tr>
+<tr><td>Private DLT with selective privacy</td><td><span class="risk-3">High Quantum Risk 3/5</span></td><td>PQ migration complicated by permissioned memberships, custom crypto stacks, contractual governance.</td></tr>
+<tr><td>Settlement / collateral infrastructure</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Less about user wallets, more about institutional concentration and migration/legal debt at infrastructure scale.</td></tr>
 </tbody>
 </table>
 </div>
@@ -1263,14 +1269,14 @@ tbody tr:last-child td { border-bottom: none; }
 <table>
 <thead><tr><th>Product Archetype</th><th>Privacy Risk</th><th>Verdict</th></tr></thead>
 <tbody>
-<tr><td>Public Ethereum/EVM tokenized funds</td><td><span class="risk-5">5/5</span></td><td>Transfers, collateral postings, liquidations widely visible. MEV and order-flow leakage around collateral adjustments.</td></tr>
-<tr><td>Public Solana/Stellar/XRPL stablecoin rails</td><td><span class="risk-4">4/5</span></td><td>Lower MEV intensity in some cases, but transparency and future decryption/graphing risk remain strong.</td></tr>
-<tr><td>Permissioned DeFi RWA markets</td><td><span class="risk-4">4/5</span></td><td>Borrowers may be permissioned, but positions, contracts, and liquidation flows remain inspectable on public chains.</td></tr>
-<tr><td>CeFi triparty / off-exchange collateral</td><td><span class="risk-3">3/5</span></td><td>Lower public leakage, but institutions overestimate confidentiality when custodian, exchange, and regulator visibility remains extensive.</td></tr>
-<tr><td>Private token mirrors and bank ledgers</td><td><span class="risk-3">3/5</span></td><td>The danger is assuming permissioned privacy equals cryptographic privacy. It usually does not.</td></tr>
-<tr><td>Canton-style selective privacy</td><td><span class="risk-4">4/5</span></td><td>Privacy depends on classical encryption, not quantum-durable cryptography. When keys break, all historical flows become retroactively visible. Divulgence documented. HNDL active.</td></tr>
-<tr><td>Stablecoin reserve stacks</td><td><span class="risk-4">4/5</span></td><td>Reserve movements reveal strategic treasury behavior. Store-now-decrypt-later creates latent future disclosure risk.</td></tr>
-<tr><td>Payments / tokenized deposit systems</td><td>2/5</td><td>Better operational confidentiality, but privacy depends on operator trust and eventual cryptographic migration.</td></tr>
+<tr><td>Public Ethereum/EVM tokenized funds</td><td><span class="risk-5">Highly Critical Quantum Risk 5/5</span></td><td>Transfers, collateral postings, liquidations widely visible. MEV and order-flow leakage around collateral adjustments.</td></tr>
+<tr><td>Public Solana/Stellar/XRPL stablecoin rails</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Lower MEV intensity in some cases, but transparency and future decryption/graphing risk remain strong.</td></tr>
+<tr><td>Permissioned DeFi RWA markets</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Borrowers may be permissioned, but positions, contracts, and liquidation flows remain inspectable on public chains.</td></tr>
+<tr><td>CeFi triparty / off-exchange collateral</td><td><span class="risk-3">High Quantum Risk 3/5</span></td><td>Lower public leakage, but institutions overestimate confidentiality when custodian, exchange, and regulator visibility remains extensive.</td></tr>
+<tr><td>Private token mirrors and bank ledgers</td><td><span class="risk-3">High Quantum Risk 3/5</span></td><td>The danger is assuming permissioned privacy equals cryptographic privacy. It usually does not.</td></tr>
+<tr><td>Canton-style selective privacy</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Privacy depends on classical encryption, not quantum-durable cryptography. When keys break, all historical flows become retroactively visible. Divulgence documented. HNDL active.</td></tr>
+<tr><td>Stablecoin reserve stacks</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Reserve movements reveal strategic treasury behavior. Store-now-decrypt-later creates latent future disclosure risk.</td></tr>
+<tr><td>Payments / tokenized deposit systems</td><td><span class="risk-2">Medium Quantum Risk 2/5</span></td><td>Better operational confidentiality, but privacy depends on operator trust and eventual cryptographic migration.</td></tr>
 </tbody>
 </table>
 </div>
@@ -1291,16 +1297,16 @@ tbody tr:last-child td { border-bottom: none; }
 <tr><th>Chain / Ledger</th><th>Institutions / Products</th><th>Value Exposed</th><th>Signature Primitives</th><th>PQ Migration</th><th>PQ Risk</th><th>Privacy Risk</th><th>Verdict</th></tr>
 </thead>
 <tbody>
-<tr><td><strong>Ethereum</strong></td><td>BUIDL, USYC, BENJI, USTB, USCC, OUSG, ACRED, RLUSD, PYUSD, EURCV, uMINT, SWEEP</td><td>&gt;$5B</td><td>secp256k1 (EOA), BLS (consensus), KZG (roadmap)</td><td>Active research, multi-year roadmap, no production migration. ~84% TPS loss modeled.</td><td><span class="risk-5">5/5</span></td><td><span class="risk-5">5/5</span></td><td>Highest-value exposure. ~84% throughput loss under PQ. Rich metadata leakage. Active research does not equal institutional readiness.</td></tr>
-<tr><td><strong>Canton</strong></td><td>USYC, Broadridge DLR ($362B ADV), Goldman/BNY institutional workflows</td><td>Significant institutional workflow exposure</td><td>Configurable crypto (classical by default), external KMS/HSM</td><td>None disclosed. ~88% TPS loss modeled under Dilithium-class PQ migration.</td><td><span class="risk-4">4/5</span></td><td><span class="risk-4">4/5</span></td><td>Privacy collapses when keys break. All historical flows become retroactively visible. Divulgence to non-stakeholders explicitly documented. HNDL attacks already active. Privacy-by-policy is not privacy-by-cryptography.</td></tr>
-<tr><td><strong>Solana</strong></td><td>USYC, USTB, USCC, PYUSD, EURCV, SWEEP</td><td>~$2.57B RWA</td><td>Ed25519</td><td>No mature PQ migration. 90% TPS loss confirmed live.</td><td><span class="risk-4">4/5</span></td><td><span class="risk-4">4/5</span></td><td>Ed25519 quantum-vulnerable. 90% throughput loss confirmed. Commercially unviable under PQ at current architecture.</td></tr>
-<tr><td><strong>Stellar</strong></td><td>BENJI, WTGXX, EURCV</td><td>~$1.8B products</td><td>Ed25519</td><td>No public PQ roadmap. ~90% TPS loss modeled.</td><td><span class="risk-4">4/5</span></td><td><span class="risk-3">3/5</span></td><td>Ed25519 quantum-vulnerable. ~90% throughput loss modeled. $1.8B+ in products with no disclosed migration path.</td></tr>
-<tr><td><strong>XRPL</strong></td><td>RLUSD, OUSG, EURCV</td><td>Not fully disclosed</td><td>Ed25519 or secp256k1</td><td>No public PQ roadmap</td><td><span class="risk-4">4/5</span></td><td><span class="risk-4">4/5</span></td><td>Public ledger with native DEX creating visible order/flow metadata. Growing institutional relevance.</td></tr>
-<tr><td><strong>Base / Arbitrum / BNB Chain / EVM L2s</strong></td><td>USYC, BENJI, VBILL, BUIDL classes, SWEEP</td><td>Material</td><td>Inherit secp256k1 from Ethereum</td><td>Optimism published PQ roadmap; broader L2 migration early</td><td><span class="risk-5">5/5</span></td><td><span class="risk-5">5/5</span></td><td>Inherit Ethereum's settlement assumptions plus sequencer/bridge metadata risk.</td></tr>
-<tr><td><strong>Aptos</strong></td><td>BENJI, ACRED</td><td>Not disclosed</td><td>Ed25519, secp256k1, passkeys/multikey</td><td>Flexible auth helps future options, no complete PQ posture</td><td><span class="risk-4">4/5</span></td><td><span class="risk-4">4/5</span></td><td>Account flexibility aids future migration, but no PQ deployment disclosed.</td></tr>
-<tr><td><strong>Avalanche</strong></td><td>BENJI, ACRED, KKR SKHC</td><td>Not disclosed</td><td>secp256k1 (AVM/EVM)</td><td>No public PQ path</td><td><span class="risk-4">4/5</span></td><td><span class="risk-4">4/5</span></td><td>Public chain. Cross-chain integrations matter more than base-layer privacy.</td></tr>
-<tr><td><strong>GS DAP</strong></td><td>BNY/Goldman tokenized MMF mirrors</td><td>Not public</td><td>Private permissioned, exact algorithms not disclosed</td><td>Lower public-chain risk, higher migration/legal debt</td><td><span class="risk-3">3/5</span></td><td><span class="risk-3">3/5</span></td><td>Classical encryption protects inter-node privacy. When those keys break, historical flows become retroactively visible. Same HNDL exposure as Canton. Concentrated operator control.</td></tr>
-<tr><td><strong>Swift shared ledger</strong></td><td>Tokenized deposits, interoperability</td><td>Flow-scale</td><td>Standards stack, crypto not fully exposed</td><td>Migration burden high: multi-party standardization</td><td><span class="risk-3">3/5</span></td><td><span class="risk-3">3/5</span></td><td>Classical encryption protects inter-bank messaging. HNDL applies. PQ migration requires coordination across 11,000+ institutions.</td></tr>
+<tr><td><strong>Ethereum</strong></td><td>BUIDL, USYC, BENJI, USTB, USCC, OUSG, ACRED, RLUSD, PYUSD, EURCV, uMINT, SWEEP</td><td>&gt;$5B</td><td>secp256k1 (EOA), BLS (consensus), KZG (roadmap)</td><td>Active research, multi-year roadmap, no production migration. ~84% TPS loss modeled.</td><td><span class="risk-5">Highly Critical Quantum Risk 5/5</span></td><td><span class="risk-5">Highly Critical Quantum Risk 5/5</span></td><td>Highest-value exposure. ~84% throughput loss under PQ. Rich metadata leakage. Active research does not equal institutional readiness.</td></tr>
+<tr><td><strong>Canton</strong></td><td>USYC, Broadridge DLR ($362B ADV), Goldman/BNY institutional workflows</td><td>Significant institutional workflow exposure</td><td>Configurable crypto (classical by default), external KMS/HSM</td><td>None disclosed. ~88% TPS loss modeled under Dilithium-class PQ migration.</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Privacy collapses when keys break. All historical flows become retroactively visible. Divulgence to non-stakeholders explicitly documented. HNDL attacks already active. Privacy-by-policy is not privacy-by-cryptography.</td></tr>
+<tr><td><strong>Solana</strong></td><td>USYC, USTB, USCC, PYUSD, EURCV, SWEEP</td><td>~$2.57B RWA</td><td>Ed25519</td><td>No mature PQ migration. 90% TPS loss confirmed live.</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Ed25519 quantum-vulnerable. 90% throughput loss confirmed. Commercially unviable under PQ at current architecture.</td></tr>
+<tr><td><strong>Stellar</strong></td><td>BENJI, WTGXX, EURCV</td><td>~$1.8B products</td><td>Ed25519</td><td>No public PQ roadmap. ~90% TPS loss modeled.</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td><span class="risk-3">High Quantum Risk 3/5</span></td><td>Ed25519 quantum-vulnerable. ~90% throughput loss modeled. $1.8B+ in products with no disclosed migration path.</td></tr>
+<tr><td><strong>XRPL</strong></td><td>RLUSD, OUSG, EURCV</td><td>Not fully disclosed</td><td>Ed25519 or secp256k1</td><td>No public PQ roadmap</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Public ledger with native DEX creating visible order/flow metadata. Growing institutional relevance.</td></tr>
+<tr><td><strong>Base / Arbitrum / BNB Chain / EVM L2s</strong></td><td>USYC, BENJI, VBILL, BUIDL classes, SWEEP</td><td>Material</td><td>Inherit secp256k1 from Ethereum</td><td>Optimism published PQ roadmap; broader L2 migration early</td><td><span class="risk-5">Highly Critical Quantum Risk 5/5</span></td><td><span class="risk-5">Highly Critical Quantum Risk 5/5</span></td><td>Inherit Ethereum's settlement assumptions plus sequencer/bridge metadata risk.</td></tr>
+<tr><td><strong>Aptos</strong></td><td>BENJI, ACRED</td><td>Not disclosed</td><td>Ed25519, secp256k1, passkeys/multikey</td><td>Flexible auth helps future options, no complete PQ posture</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Account flexibility aids future migration, but no PQ deployment disclosed.</td></tr>
+<tr><td><strong>Avalanche</strong></td><td>BENJI, ACRED, KKR SKHC</td><td>Not disclosed</td><td>secp256k1 (AVM/EVM)</td><td>No public PQ path</td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td><span class="risk-4">Critical Quantum Risk 4/5</span></td><td>Public chain. Cross-chain integrations matter more than base-layer privacy.</td></tr>
+<tr><td><strong>GS DAP</strong></td><td>BNY/Goldman tokenized MMF mirrors</td><td>Not public</td><td>Private permissioned, exact algorithms not disclosed</td><td>Lower public-chain risk, higher migration/legal debt</td><td><span class="risk-3">High Quantum Risk 3/5</span></td><td><span class="risk-3">High Quantum Risk 3/5</span></td><td>Classical encryption protects inter-node privacy. When those keys break, historical flows become retroactively visible. Same HNDL exposure as Canton. Concentrated operator control.</td></tr>
+<tr><td><strong>Swift shared ledger</strong></td><td>Tokenized deposits, interoperability</td><td>Flow-scale</td><td>Standards stack, crypto not fully exposed</td><td>Migration burden high: multi-party standardization</td><td><span class="risk-3">High Quantum Risk 3/5</span></td><td><span class="risk-3">High Quantum Risk 3/5</span></td><td>Classical encryption protects inter-bank messaging. HNDL applies. PQ migration requires coordination across 11,000+ institutions.</td></tr>
 <tr class="row-green"><td><strong>EternaX</strong></td><td>PQ-native issuance: stablecoins, RWAs, tokenized funds, collateral, settlement</td><td>Testnet live. Institutional pilots.</td><td>SPHINCS+ (NIST FIPS 205) + SILMARILS 160-byte. Hash-only. No pairings, no BLS, no KZG.</td><td>PQ-native from genesis. Zero migration debt. ~2% TPS loss. 50,000+ TPS, ~120ms finality.</td><td><span class="risk-0">0/5</span></td><td><span class="risk-0">0/5</span></td><td>The only EVM-compatible PQ-native L1. Auditable privacy. Validator-blind confidentiality. MEV-zero. No classical primitives to migrate. New issuance starts here.</td></tr>
 </tbody>
 </table>

--- a/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html
+++ b/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html
@@ -1,0 +1,1750 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#e2e2e2">
+<title>Post-Quantum Exposure Map 2026: Institutional Crypto Risk for Tokenized Assets, Stablecoins, RWAs, Collateral, Privacy | EternaX Labs</title>
+<meta name="description" content="The definitive institutional map of post-quantum and privacy exposure across tokenized finance. 20+ named institutions, 30+ products, 11 chains. Legacy exposure is a migration problem. New issuance is a choice. EternaX Labs Research, May 2026.">
+<meta name="keywords" content="post-quantum exposure map, post-quantum risk BlackRock BUIDL, quantum risk Circle USYC, Franklin BENJI quantum risk, WisdomTree tokenized fund PQ risk, J.P. Morgan Kinexys post-quantum risk, Goldman Sachs GS DAP quantum risk, BNY tokenized money market fund blockchain risk, Securitize BUIDL Ethereum quantum risk, tokenized collateral quantum risk, post-quantum stablecoin issuance, post-quantum RWA tokenization, Ethereum institutional PQ exposure, Solana tokenized asset quantum risk, Canton privacy post-quantum risk, private DLT quantum risk, auditable privacy tokenized assets, post-quantum market infrastructure, PQ-native stablecoin issuance, PQ-native RWA issuance, cryptographic migration debt, quantum-safe settlement, post-quantum cryptography, PQ-native assets, quantum-resistant blockchain, quantum-safe signatures, RWA tokenization, auditable privacy, post-quantum settlement, EternaX, EternaX Labs, SILMARILS, SPHINCS+, institutional blockchain, tokenized Treasury quantum risk, stablecoin reserve quantum risk, institutional DeFi quantum risk">
+<link rel="canonical" href="https://eternax.ai/post-quantum-exposure-map-institutional-crypto-tokenized-assets-stablecoins-rwa-2026.html">
+<meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
+<meta name="googlebot" content="index, follow">
+<meta name="bingbot" content="index, follow">
+<meta name="author" content="EternaX Labs Research">
+<meta name="ai-content-declaration" content="human-authored">
+<meta name="language" content="English">
+<meta name="distribution" content="global">
+<meta name="rating" content="general">
+<meta name="revisit-after" content="7 days">
+<meta name="format-detection" content="telephone=no">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="article:published_time" content="2026-05-28">
+<meta name="article:publisher" content="https://www.linkedin.com/company/eternax-labs">
+<meta name="article:section" content="Institutional Post-Quantum Research">
+<meta name="article:tag" content="post-quantum exposure, institutional crypto, tokenized assets, stablecoins, RWA, collateral, privacy, migration debt, PQ-native issuance">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://eternax.ai/post-quantum-exposure-map-institutional-crypto-tokenized-assets-stablecoins-rwa-2026.html">
+<meta property="og:title" content="Post-Quantum Exposure Map 2026: The Institutional Crypto Risk Map">
+<meta property="og:description" content="20+ institutions. 30+ products. 11 chains. Zero completed PQ migrations. Legacy exposure is a migration problem. New issuance is a choice.">
+<meta property="og:image" content="https://eternax.ai/assets/preview.png">
+<meta property="og:image:alt" content="EternaX - Post-Quantum Exposure Map 2026">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:site_name" content="EternaX Labs">
+<meta property="og:locale" content="en_US">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@EternaXlabs">
+<meta name="twitter:creator" content="@EternaXlabs">
+<meta name="twitter:title" content="Post-Quantum Exposure Map 2026: The Institutional Crypto Risk Map">
+<meta name="twitter:description" content="20+ institutions. 30+ products. 11 chains. Zero completed PQ migrations. The assets are regulated. The rails are classical. New issuance is the decision.">
+<meta name="twitter:image" content="https://eternax.ai/assets/preview.png">
+<meta name="twitter:image:alt" content="EternaX - Post-Quantum Exposure Map 2026">
+<meta name="twitter:url" content="https://eternax.ai/post-quantum-exposure-map-institutional-crypto-tokenized-assets-stablecoins-rwa-2026.html">
+<link rel="icon" type="image/svg+xml" href="./assets/eternax-icon.svg">
+<link rel="icon" type="image/png" href="./assets/eternax-icon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Serif:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./styles/tailwind.generated.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "EternaX Labs",
+  "alternateName": "eternaX",
+  "url": "https://eternax.ai",
+  "logo": "https://eternax.ai/assets/eternax-icon.svg",
+  "description": "Post-quantum market infrastructure for stablecoin issuance, RWA tokenization, and institutional settlement.",
+  "foundingDate": "2025",
+  "industry": "Post-Quantum Market Infrastructure",
+  "sameAs": [
+    "https://x.com/eternaXLabs",
+    "https://github.com/eternax-ai",
+    "https://www.youtube.com/@eternaXlabs",
+    "https://farcaster.xyz/eternax",
+    "https://www.linkedin.com/company/eternax-labs"
+  ],
+  "founder": [
+    {"@type": "Person", "name": "Paarrthhh Birla"},
+    {"@type": "Person", "name": "Dariia Porechna"},
+    {"@type": "Person", "name": "Dr. Chen Feng"}
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Post-Quantum Exposure Map 2026: The Institutional Crypto Risk Map for Tokenized Assets, Stablecoins, RWAs, Collateral, Privacy, and New Issuance",
+  "author": [
+    {"@type": "Person", "name": "Paarrthhh Birla", "jobTitle": "Co-Founder", "affiliation": {"@type": "Organization", "name": "EternaX Labs"}, "url": "https://www.linkedin.com/in/paarrthhh-birla-b3607bb4/"},
+    {"@type": "Person", "name": "Dariia Porechna", "jobTitle": "Co-Founder", "affiliation": {"@type": "Organization", "name": "EternaX Labs"}, "url": "https://www.linkedin.com/in/dariia-porechna"},
+    {"@type": "Person", "name": "Dr. Chen Feng", "jobTitle": "Chief Scientist", "affiliation": {"@type": "Organization", "name": "University of British Columbia"}, "url": "https://scholar.google.com/citations?user=D8b0l-EAAAAJ"}
+  ],
+  "publisher": {"@type": "Organization", "name": "EternaX Labs", "url": "https://eternax.ai", "logo": {"@type": "ImageObject", "url": "https://eternax.ai/assets/eternax-icon.svg"}},
+  "datePublished": "2026-05-28",
+  "dateModified": "2026-05-28",
+  "description": "The definitive institutional map of post-quantum and privacy exposure across tokenized finance. Maps 20+ institutions, 30+ products, 11 chains to specific PQ and privacy risks, business impact, and new issuance decisions.",
+  "url": "https://eternax.ai/post-quantum-exposure-map-institutional-crypto-tokenized-assets-stablecoins-rwa-2026.html",
+  "mainEntityOfPage": "https://eternax.ai/post-quantum-exposure-map-institutional-crypto-tokenized-assets-stablecoins-rwa-2026.html",
+  "keywords": ["post-quantum cryptography", "tokenized assets", "stablecoins", "RWA tokenization", "institutional crypto", "cryptographic migration debt", "PQ-native issuance", "BlackRock BUIDL", "Circle USYC", "Franklin BENJI", "Ethereum quantum risk", "Solana quantum risk", "Canton privacy", "auditable privacy", "EternaX"],
+  "about": [
+    {"@type": "Thing", "name": "Post-quantum cryptography"},
+    {"@type": "Thing", "name": "Tokenized assets"},
+    {"@type": "Thing", "name": "Cryptographic migration debt"},
+    {"@type": "Thing", "name": "PQ-native blockchain infrastructure"}
+  ],
+  "wordCount": "12000"
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "DataCatalog",
+  "name": "Institutional Post-Quantum Exposure Database",
+  "description": "Maps 20+ named institutions, 30+ tokenized products, and 11 blockchain networks to post-quantum and privacy risk scores, business impact, and new issuance decisions.",
+  "url": "https://eternax.ai/post-quantum-exposure-map-institutional-crypto-tokenized-assets-stablecoins-rwa-2026.html",
+  "creator": {"@type": "Organization", "name": "EternaX Labs"},
+  "datePublished": "2026-05-28",
+  "dataset": [
+    {"@type": "Dataset", "name": "Institutional PQ Exposure Map", "description": "24 institutions mapped to products, chains, PQ risk scores, and new issuance decisions"},
+    {"@type": "Dataset", "name": "Chain and Ledger PQ Risk Scores", "description": "11 blockchain networks scored for post-quantum and privacy risk with signature primitive analysis"},
+    {"@type": "Dataset", "name": "Top 10 Institutional Pilots at Risk", "description": "10 live institutional crypto pilots assessed for PQ vulnerability and migration debt"}
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {"@type": "Question", "name": "What is the post-quantum risk to BlackRock BUIDL?", "acceptedAnswer": {"@type": "Answer", "text": "BUIDL is the single largest PQ dependency cluster in tokenized finance. It combines public-chain wallet signatures (secp256k1), concentrated admin and transfer-agent keys via Securitize, multichain smart contract exposure across Ethereum and additional chains, and downstream reserve dependencies in products like OUSG and USDtb. It is used as collateral on OKX, Binance, Hidden Road, and Komainu. No end-to-end PQ migration plan has been disclosed."}},
+    {"@type": "Question", "name": "What is the post-quantum exposure of Circle USYC?", "acceptedAnswer": {"@type": "Answer", "text": "USYC is deployed across Base, Canton, Ethereum, NEAR, and Solana, carrying the full public-chain PQ risk stack on each network. It operates a two-token model requiring interoperability with USDC redemption rails and Circle-operated attestation services. Deribit accepts USYC as yield-bearing cross-margin collateral for derivatives. Every chain it touches uses classical signatures with no completed PQ migration."}},
+    {"@type": "Question", "name": "Is Franklin BENJI post-quantum safe?", "acceptedAnswer": {"@type": "Answer", "text": "No. BENJI now touches nine public blockchains (Stellar, Polygon, Arbitrum, Avalanche, Aptos, Base, Ethereum, Solana, BNB Smart Chain), each using Ed25519 or secp256k1 signatures. The transfer agent maintains centralized administrative override, creating concentrated control-plane risk. Each new chain deployment compounds the migration debt."}},
+    {"@type": "Question", "name": "What is the post-quantum risk to tokenized Treasury funds?", "acceptedAnswer": {"@type": "Answer", "text": "Tokenized Treasury funds including BUIDL ($2.5B), iBENJI ($1.56B), USTB ($988M), JTRSY ($970M), WTGXX ($951M), and BENJI ($825M) all rely on classical cryptographic signatures for wallet access, admin control, smart contracts, and cross-chain messaging. The underlying Treasury assets are low risk. The cryptographic rails carrying them are quantum-vulnerable."}},
+    {"@type": "Question", "name": "Is Solana post-quantum safe for tokenized assets?", "acceptedAnswer": {"@type": "Answer", "text": "No. Solana uses Ed25519 signatures, which are vulnerable to quantum attack via Shor's algorithm. In April 2026, Project Eleven and the Solana Foundation confirmed approximately 90% throughput loss on a live testnet when quantum-resistant signatures were tested. Approximately $2.57 billion in RWA value on Solana is exposed."}},
+    {"@type": "Question", "name": "What is the post-quantum risk to Ethereum institutional tokenization?", "acceptedAnswer": {"@type": "Answer", "text": "Ethereum has the highest combined PQ and privacy risk score (5/5 on both). EOA wallets use secp256k1. Consensus uses BLS. The roadmap identifies ECDSA, BLS, KZG, and ZK systems as quantum-sensitive. Over $5 billion in tokenized products touch Ethereum. Active PQ research exists, but the roadmap is multi-year with no production migration completed."}},
+    {"@type": "Question", "name": "Is Canton Network post-quantum secure?", "acceptedAnswer": {"@type": "Answer", "text": "No. Canton's privacy depends on classical encryption and permissioned access, not quantum-durable cryptography. When keys break, all historical flows become retroactively visible. Divulgence to non-stakeholders is explicitly documented. Approximately 88% TPS loss modeled under PQ migration. HNDL attacks already active. Privacy-by-policy is not privacy-by-cryptography."}},
+    {"@type": "Question", "name": "Is private DLT post-quantum safe?", "acceptedAnswer": {"@type": "Answer", "text": "No. Private and permissioned ledgers (GS DAP, Kinexys, Canton, Swift shared ledger) reduce public observability but do not automatically deliver PQ security. Their cryptographic primitives are often classical, their KMS and HSM integrations depend on classical key material, and their migration burden is high."}},
+    {"@type": "Question", "name": "What is cryptographic migration debt?", "acceptedAnswer": {"@type": "Answer", "text": "Cryptographic migration debt is the accumulated cost and coordination burden of transitioning live digital asset infrastructure from classical to post-quantum cryptographic primitives. It includes re-keying wallets, rotating admin and transfer-agent keys, updating smart contracts, migrating bridge and oracle signer sets, re-papering legal agreements, and coordinating across custodians, exchanges, and counterparties."}},
+    {"@type": "Question", "name": "How does post-quantum risk affect tokenized collateral?", "acceptedAnswer": {"@type": "Answer", "text": "Tokenized collateral faces repricing risk before any quantum computer breaks a key. As the market begins to price quantum risk, haircuts widen, collateral eligibility narrows, and margin treatment tightens. The commercial consequence precedes the technical event."}},
+    {"@type": "Question", "name": "What is the post-quantum risk to stablecoin reserves?", "acceptedAnswer": {"@type": "Answer", "text": "Stablecoins backed by tokenized MMFs or Treasuries create stacked dependencies. The stablecoin admin keys sit on top of the reserve asset admin/oracle/bridge dependence. Wrong-way risk appears if the reserve asset or issuer workflow fails during stress."}},
+    {"@type": "Question", "name": "What is auditable privacy for tokenized assets?", "acceptedAnswer": {"@type": "Answer", "text": "Auditable privacy means institutional flows are cryptographically protected from public visibility and store-now-decrypt-later harvesting, while remaining selectively disclosable to authorized supervisors, auditors, and regulators. Public chains cannot meet this requirement. Private DLT addresses it only through operator trust, not cryptographic guarantees."}},
+    {"@type": "Question", "name": "What is PQ-native issuance?", "acceptedAnswer": {"@type": "Answer", "text": "PQ-native issuance means launching new stablecoins, tokenized funds, RWAs, collateral rails, or settlement corridors on infrastructure where post-quantum cryptographic security is built in from genesis, not retrofitted. The issuer inherits zero migration debt on day one."}},
+    {"@type": "Question", "name": "What is PQ-native blockchain infrastructure for institutional use?", "acceptedAnswer": {"@type": "Answer", "text": "PQ-native blockchain infrastructure is a chain where post-quantum security, auditable privacy, and institutional-grade execution are native from block zero. EternaX delivers SPHINCS+ as the conservative NIST standard, SILMARILS as the 160-byte speed/size optimization, approximately 2% TPS loss versus 84-90% on incumbents, validator-blind confidentiality, MEV-zero architecture, and EVM compatibility."}},
+    {"@type": "Question", "name": "What is the post-quantum risk to institutional market infrastructure?", "acceptedAnswer": {"@type": "Answer", "text": "DTCC, Swift, Broadridge, Fnality, and similar infrastructure face less public-holder theft risk but the heaviest migration and legal debt. Broadridge processes $362 billion in average daily repo volume on DLT. The risk is concentration and coordination, not individual wallet compromise."}},
+    {"@type": "Question", "name": "What is the post-quantum risk to J.P. Morgan Kinexys?", "acceptedAnswer": {"@type": "Answer", "text": "Kinexys is a bank-led blockchain platform that has processed over $1.5 trillion in notional value. It operates on a private ledger with enterprise-grade KMS and admin controls. The PQ risk is control-plane concentration: bank admin keys, KMS migration, and legal continuity across tokenized deposits and interoperability with external tokenized-asset networks."}},
+    {"@type": "Question", "name": "What is the post-quantum risk to Goldman Sachs GS DAP?", "acceptedAnswer": {"@type": "Answer", "text": "GS DAP is a private permissioned blockchain that mirrors tokenized MMF share classes for BNY LiquidityDirect. The exact cryptographic primitives in production are not publicly disclosed. The PQ risk sits in concentrated operator and admin key exposure, KMS dependency, and migration debt across banks, funds, client books, custody, and legacy systems."}},
+    {"@type": "Question", "name": "What is the post-quantum risk to WisdomTree tokenized funds?", "acceptedAnswer": {"@type": "Answer", "text": "WisdomTree WTGXX ($951M) operates on Stellar (Ed25519) and Ethereum (secp256k1), both quantum-vulnerable via Shor's algorithm. Migration requires coordination across fund administration, chain infrastructure, and regulatory filings. No PQ migration plan has been publicly disclosed."}},
+    {"@type": "Question", "name": "What should VCs and institutional allocators evaluate for post-quantum risk in tokenized asset portfolios?", "acceptedAnswer": {"@type": "Answer", "text": "VCs and allocators should evaluate five dimensions: which chain carries the asset and its classical primitives, who holds admin keys and whether they have PQ hardening, bridge/oracle/messaging dependencies, whether the product creates compounding migration debt, and whether new issuance decisions are being made on PQ-native rails. PQ-native positioning is not only risk mitigation; it is a distribution advantage in a crowded tokenization market."}}
+  ]
+}
+</script>
+<style>
+:root {
+  --brand: #283771;
+  --bg: #F7F4F4;
+  --surface: #FFFFFF;
+  --border: #E0DEDE;
+  --green: #2F5E52;
+  --red: #8D2E2E;
+  --text: #283771;
+  --text-secondary: #4a5568;
+  --text-muted: #6b7280;
+  --accent-bg: #EBE8E8;
+  --highlight: #f0eeed;
+  --stat-bg: #283771;
+  --stat-text: #F7F4F4;
+  --font: 'IBM Plex Sans', ui-sans-serif, system-ui, sans-serif;
+  --serif: 'IBM Plex Serif', serif;
+  --mono: 'IBM Plex Mono', 'Courier New', monospace;
+  --fg: #283771;
+  --fg-70: rgba(40, 55, 113, 0.7);
+  --fg-80: rgba(40, 55, 113, 0.8);
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; font-size: 16px; }
+
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.72;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+nav { font-family: ui-sans-serif, system-ui, sans-serif; --fg-70: var(--fg); --fg-80: var(--fg); }
+
+.btn-primary { background-color: var(--brand); transition: background-color .15s; color: #fff; }
+.btn-primary:hover { background-color: #37457B; }
+.glass-effect { background: #fff; border: 1px solid var(--border); box-shadow: 0 1px 3px rgba(0,0,0,.06); }
+.nav-products-dropdown { opacity: 0; visibility: hidden; transition: opacity .15s, visibility .15s; }
+.group:hover .nav-products-dropdown { opacity: 1; visibility: visible; }
+
+/* COVER */
+.cover {
+  border-bottom: 1px solid var(--border);
+  padding: calc(2.5rem + 64px) 0 2rem;
+  background: linear-gradient(180deg, #FFFFFF 0%, var(--bg) 100%);
+}
+.cover-inner {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+.cover-eyebrow {
+  font-family: var(--font);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 1.8px;
+  text-transform: uppercase;
+  color: var(--green);
+  margin-bottom: 1rem;
+}
+.cover-title {
+  font-family: var(--font);
+  font-size: 2.35rem;
+  font-weight: 700;
+  line-height: 1.22;
+  letter-spacing: -0.3px;
+  color: #1A2550;
+  margin-bottom: 1rem;
+}
+.cover-subtitle {
+  font-family: var(--serif);
+  font-size: 1.08rem;
+  font-weight: 400;
+  font-style: italic;
+  color: #4A4A4A;
+  line-height: 1.6;
+  margin-bottom: 1.25rem;
+}
+.cover-meta {
+  margin-top: 1.25rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.cover-meta-item {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.cover-meta-label {
+  margin-bottom: 0.3rem;
+}
+.cover-meta-value {
+  color: var(--text);
+}
+
+/* LAYOUT */
+.container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+section {
+  padding: 4rem 0;
+  border-bottom: 1px solid var(--border);
+}
+section:last-of-type { border-bottom: none; }
+
+/* TYPOGRAPHY */
+h1 {
+  font-family: 'IBM Plex Serif', serif;
+  font-size: 2.4rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--brand);
+  letter-spacing: -0.02em;
+  margin-bottom: 0.5rem;
+}
+h2 {
+  font-family: 'IBM Plex Serif', serif;
+  font-size: 1.6rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--brand);
+  margin-bottom: 1.25rem;
+  letter-spacing: -0.01em;
+}
+h3 {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--brand);
+  margin-bottom: 0.75rem;
+  margin-top: 2rem;
+}
+p { margin-bottom: 1rem; }
+strong { font-weight: 600; }
+.link-muted { color: var(--text-muted); text-decoration: none; }
+.link-muted:hover { color: var(--text); }
+
+.subtitle {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 1.15rem;
+  font-weight: 400;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+.meta-line {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin-bottom: 0.4rem;
+  font-weight: 400;
+}
+
+.section-label {
+  font-family: 'IBM Plex Sans Condensed', 'IBM Plex Sans', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+/* HERO OPENER */
+.hero-line {
+  font-family: 'IBM Plex Serif', serif;
+  font-size: 1.35rem;
+  font-weight: 500;
+  color: var(--red);
+  line-height: 1.5;
+  margin-bottom: 2.5rem;
+  padding-left: 1.25rem;
+  border-left: 3px solid var(--red);
+}
+
+/* STAT CALLOUTS */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 2.5rem 0;
+}
+.stat-card {
+  background: var(--stat-bg);
+  color: var(--stat-text);
+  padding: 1.5rem 1.25rem;
+  border-radius: 6px;
+}
+.stat-number {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.1;
+  margin-bottom: 0.5rem;
+}
+.stat-label {
+  font-size: 0.78rem;
+  font-weight: 400;
+  line-height: 1.45;
+  opacity: 0.85;
+}
+
+/* KEY FINDINGS */
+.findings {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 2rem;
+  margin: 2.5rem 0;
+}
+.findings ol {
+  padding-left: 1.5rem;
+}
+.findings li {
+  margin-bottom: 0.75rem;
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+.findings li:last-child { margin-bottom: 0; }
+
+/* WHY NOW TABLE */
+.forcing-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2rem 0;
+  font-size: 0.85rem;
+}
+.forcing-table th {
+  text-align: left;
+  font-weight: 600;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid var(--brand);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+.forcing-table td {
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.forcing-table td:first-child {
+  font-weight: 600;
+  white-space: nowrap;
+  color: var(--brand);
+  width: 120px;
+}
+
+/* TABLES */
+.table-wrap {
+  overflow-x: auto;
+  margin: 1.5rem 0 2rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+thead th {
+  background: var(--brand);
+  color: var(--stat-text);
+  font-weight: 600;
+  padding: 0.65rem 0.6rem;
+  text-align: left;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+}
+tbody td {
+  padding: 0.6rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+tbody tr:hover { background: var(--highlight); }
+tbody tr:last-child td { border-bottom: none; }
+
+.risk-5 { color: var(--red); font-weight: 700; }
+.risk-4 { color: #9c4a1a; font-weight: 600; }
+.risk-3 { color: #7c6a1f; font-weight: 600; }
+
+/* CALLOUT BLOCKS */
+.callout {
+  background: var(--surface);
+  border-left: 3px solid var(--red);
+  padding: 1.25rem 1.5rem;
+  margin: 1.5rem 0;
+  border-radius: 0 6px 6px 0;
+}
+.callout-title {
+  font-weight: 600;
+  font-size: 0.88rem;
+  margin-bottom: 0.4rem;
+  color: var(--brand);
+}
+.callout p { font-size: 0.85rem; margin-bottom: 0; color: var(--text-secondary); }
+
+.callout-green {
+  border-left-color: var(--green);
+}
+
+/* SECTION CLOSERS */
+.section-closer {
+  font-family: 'IBM Plex Serif', serif;
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: var(--brand);
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+  line-height: 1.5;
+}
+
+/* DECISION TABLE */
+.decision-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.85rem;
+}
+.decision-table th {
+  text-align: left;
+  font-weight: 600;
+  padding: 0.7rem 0.75rem;
+  border-bottom: 2px solid var(--brand);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.decision-table td {
+  padding: 0.7rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.decision-table td:first-child { font-weight: 500; }
+
+/* TRIPLE ADVANTAGE */
+.advantage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
+  margin: 2rem 0;
+}
+.advantage-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1.5rem;
+}
+.advantage-card h3 {
+  margin-top: 0;
+  font-size: 0.95rem;
+}
+.advantage-card p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-bottom: 0;
+}
+
+/* FAQ */
+.faq-item {
+  border-bottom: 1px solid var(--border);
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-item summary {
+  padding: 1.25rem 0;
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.faq-item summary::-webkit-details-marker { display: none; }
+.faq-item summary::after {
+  content: '+';
+  font-size: 1.2rem;
+  font-weight: 300;
+  color: var(--text-muted);
+  transition: transform 0.2s;
+  flex-shrink: 0;
+  margin-left: 1rem;
+}
+.faq-item[open] summary::after {
+  content: '\2212';
+}
+.faq-item summary h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--brand);
+  font-weight: 600;
+}
+.faq-item .faq-answer {
+  padding: 0 0 1.25rem;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+/* GREEN ROW for EternaX in chain table */
+.risk-badge-0 { background: var(--green); color: #fff; }
+.risk-0 { color: var(--green); font-weight: 700; }
+.row-green td { background: rgba(47, 94, 82, 0.06); }
+.row-green td:first-child { border-left: 3px solid var(--green); }
+
+/* CTA */
+.cta-block {
+  background: var(--brand);
+  color: var(--stat-text);
+  padding: 2.5rem;
+  border-radius: 6px;
+  margin: 2.5rem 0;
+  text-align: center;
+}
+.cta-block p {
+  font-family: 'IBM Plex Serif', serif;
+  font-size: 1.15rem;
+  font-weight: 500;
+  line-height: 1.6;
+  margin-bottom: 1.25rem;
+  color: var(--stat-text);
+}
+.cta-block p:last-child { margin-bottom: 0; }
+.cta-link {
+  display: inline-block;
+  background: var(--stat-text);
+  color: var(--brand);
+  padding: 0.6rem 1.5rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.88rem;
+  margin-top: 0.5rem;
+}
+
+/* PULL QUOTES */
+.pull-quote {
+  font-family: 'IBM Plex Serif', serif;
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: var(--brand);
+  line-height: 1.5;
+  padding: 1.75rem 2rem;
+  margin: 2.5rem 0;
+  background: var(--surface);
+  border-left: 4px solid var(--brand);
+  border-radius: 0 6px 6px 0;
+  box-shadow: 0 1px 3px rgba(40, 55, 113, 0.06);
+}
+
+/* INSTITUTION CARDS */
+.inst-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.25rem;
+  margin: 2rem 0;
+}
+.inst-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1.35rem;
+  transition: box-shadow 0.2s;
+}
+.inst-card:hover {
+  box-shadow: 0 2px 8px rgba(40, 55, 113, 0.08);
+}
+.inst-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 0.6rem;
+}
+.inst-card-name {
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: var(--brand);
+}
+.inst-card-product {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+}
+.inst-card-meta {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-bottom: 0.6rem;
+  line-height: 1.5;
+}
+.inst-card-risk {
+  font-size: 0.8rem;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--border);
+}
+.risk-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.15rem 0.45rem;
+  border-radius: 3px;
+  margin-left: 0.25rem;
+}
+.risk-badge-5 { background: var(--red); color: #fff; }
+.risk-badge-4 { background: #9c4a1a; color: #fff; }
+.risk-badge-3 { background: #7c6a1f; color: #fff; }
+
+/* SECTION DIVIDER */
+.section-divider {
+  text-align: center;
+  padding: 2rem 0;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+.section-divider::before {
+  content: '';
+  display: block;
+  width: 40px;
+  height: 2px;
+  background: var(--brand);
+  margin: 0 auto 1rem;
+}
+
+/* COMPACT TABLE (for summary view) */
+.compact-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.compact-table thead th {
+  background: var(--brand);
+  color: var(--stat-text);
+  font-weight: 600;
+  padding: 0.6rem 0.65rem;
+  text-align: left;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+.compact-table tbody td {
+  padding: 0.55rem 0.65rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.compact-table tbody tr:hover { background: var(--highlight); }
+.compact-table tbody tr:last-child td { border-bottom: none; }
+.compact-table .inst-name { font-weight: 600; color: var(--brand); white-space: nowrap; }
+
+@media (max-width: 768px) {
+  .inst-grid { grid-template-columns: 1fr; }
+  .pull-quote { font-size: 1.05rem; padding: 1.25rem 1.25rem; }
+}
+
+/* TEAM + CONTACT + REPORT FOOTER (aligned with other reports) */
+.team-section,.connect-section{padding-left:2rem;padding-right:2rem}
+.team-inner,.connect-inner{max-width:860px;margin:0 auto}
+.team-section{
+  border-top:1px solid var(--border);
+  border-bottom:1px solid var(--border);
+  padding-top:3rem;padding-bottom:3rem;background:var(--bg)
+}
+.team-label{font-size:.68rem;font-weight:700;color:var(--text-muted);margin-bottom:.6rem}
+.team-section h2{font-family:'IBM Plex Serif',serif;font-size:1.3rem;color:var(--text);margin-bottom:1.5rem}
+.team-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.25rem}
+.team-card{background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:1.2rem 1.2rem 1rem}
+.team-name{font-size:.9rem;font-weight:600;color:var(--text);margin-bottom:.1rem}
+.team-role{font-family:'IBM Plex Mono',monospace;font-size:.62rem;letter-spacing:.08em;text-transform:uppercase;color:#37457B;margin-bottom:.6rem}
+.team-bio{font-size:.78rem;color:var(--text-muted);line-height:1.55;margin-bottom:.7rem}
+.team-links{font-family:'IBM Plex Mono',monospace;font-size:.62rem;color:var(--text-muted)}
+.team-links a{text-decoration:none}
+.team-links a:hover{color:var(--text)}
+.connect-section{
+  border-bottom:1px solid var(--border);
+  padding-top:3rem;padding-bottom:3rem;background:var(--bg)
+}
+.connect-label{font-size:.68rem;font-weight:700;color:var(--text-muted);margin-bottom:.6rem;text-align:center}
+.connect-section h2{font-family:'IBM Plex Serif',serif;font-size:1.3rem;color:var(--text);margin-bottom:.6rem;text-align:center}
+.connect-intro{font-size:.9rem;color:var(--text-muted);line-height:1.65;max-width:620px;margin:0 auto 2rem;text-align:center}
+.connect-contacts{display:flex;flex-direction:column;align-items:center;gap:.6rem;margin-bottom:2.5rem}
+.connect-person{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;justify-content:center;font-size:.82rem}
+.connect-person .name{font-weight:600;color:var(--text);min-width:180px;text-align:right}
+.connect-person .role{font-family:'IBM Plex Mono',monospace;font-size:.68rem;color:var(--text-muted);min-width:90px;text-align:left}
+.connect-person .email{font-family:'IBM Plex Mono',monospace;font-size:.75rem;color:#37457B;text-decoration:none}
+.connect-sep{color:var(--text-muted);margin:0 .25rem}
+
+.report-footer{background:var(--bg);border-top:1px solid var(--border);padding:3rem 0}
+.report-footer-inner{max-width:860px;margin:0 auto;padding:0 40px}
+.report-footer h3{font-size:.7rem;font-weight:600;color:var(--text-muted);margin-bottom:1rem;letter-spacing:.08em;text-transform:uppercase}
+.report-footer p{font-size:.75rem;color:var(--text-muted);line-height:1.72;margin-bottom:.8rem}
+
+@media(max-width:700px){
+  .team-section,.connect-section{padding-left:1rem;padding-right:1rem}
+  .team-grid{grid-template-columns:1fr}
+  .connect-person{flex-direction:column;gap:.2rem}
+  .connect-person .name,.connect-person .role{min-width:auto;text-align:center}
+}
+
+/* RISK CHAIN EXPLAINER */
+.risk-chain {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0;
+  margin: 2rem 0 2.5rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--surface);
+}
+.risk-chain-step {
+  padding: 1.25rem 1rem;
+  border-right: 1px solid var(--border);
+  position: relative;
+}
+.risk-chain-step:last-child { border-right: none; }
+.risk-chain-step::after {
+  content: '\2192';
+  position: absolute;
+  right: -8px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1.1rem;
+  color: var(--text-muted);
+  z-index: 1;
+  background: var(--surface);
+  padding: 2px;
+}
+.risk-chain-step:last-child::after { display: none; }
+.risk-chain-num {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.35rem;
+}
+.risk-chain-title {
+  font-weight: 600;
+  font-size: 0.88rem;
+  color: var(--brand);
+  margin-bottom: 0.3rem;
+}
+.risk-chain-detail {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.primitive-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.82rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.primitive-table th {
+  background: var(--red);
+  color: var(--stat-text);
+  font-weight: 600;
+  padding: 0.55rem 0.75rem;
+  text-align: left;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.primitive-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.primitive-table tbody tr:last-child td { border-bottom: none; }
+.primitive-table code {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.78rem;
+  background: var(--highlight);
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+}
+
+@media (max-width: 768px) {
+  .risk-chain { grid-template-columns: 1fr; }
+  .risk-chain-step { border-right: none; border-bottom: 1px solid var(--border); }
+  .risk-chain-step:last-child { border-bottom: none; }
+  .risk-chain-step::after { display: none; }
+}
+
+/* TABLE OF CONTENTS */
+.toc {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1.5rem 2rem;
+  margin: 2rem 0 0;
+}
+.toc-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+}
+.toc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.35rem 2rem;
+}
+.toc-grid a {
+  font-size: 0.84rem;
+  color: var(--brand);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 0.25rem 0;
+  display: block;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.2s;
+}
+.toc-grid a:hover { border-bottom-color: var(--brand); }
+.toc-grid a span { color: var(--text-muted); font-weight: 400; margin-right: 0.5rem; font-size: 0.78rem; }
+
+/* PILOTS TABLE */
+.pilot-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1.25rem 1.5rem;
+  margin: 1.25rem 0;
+}
+.pilot-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 0.5rem;
+}
+.pilot-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--brand);
+}
+.pilot-what {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.6rem;
+  line-height: 1.55;
+}
+.pilot-break {
+  font-size: 0.82rem;
+  line-height: 1.55;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--border);
+}
+.pilot-break strong { color: var(--red); }
+.pilot-verdict {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--brand);
+  margin-top: 0.5rem;
+  font-style: italic;
+}
+.pilot-alt {
+  font-size: 0.78rem;
+  color: var(--green);
+  font-weight: 600;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed var(--green);
+}
+
+/* RESPONSIVE */
+@media (max-width: 768px) {
+  h1 { font-size: 1.7rem; }
+  h2 { font-size: 1.3rem; }
+  .stats-grid { grid-template-columns: repeat(2, 1fr); }
+  .container { padding: 0 1rem; }
+  section { padding: 2.5rem 0; }
+  .hero-line { font-size: 1.1rem; }
+  .stat-number { font-size: 1.5rem; }
+  .advantage-grid { grid-template-columns: 1fr; }
+  .cover-title { font-size: 1.75rem; }
+}
+@media (max-width: 480px) {
+  .stats-grid { grid-template-columns: 1fr; }
+  h1 { font-size: 1.4rem; }
+}
+</style>
+</head>
+<body>
+
+{% include navbar.html %}
+
+<!-- HEADER -->
+<header class="cover" role="banner">
+<div class="cover-inner">
+<div class="cover-eyebrow">EternaX Research &middot; Institutional Post-Quantum Exposure &middot; May 2026</div>
+<h1 class="cover-title">Post-Quantum Exposure Map 2026</h1>
+<p class="cover-subtitle">The Institutional Crypto Risk Map for Tokenized Assets, Stablecoins, RWAs, Collateral, Privacy, and New Issuance</p>
+<div class="cover-meta">
+  <div class="cover-meta-item"><div class="cover-meta-label">Authors</div><div class="cover-meta-value">Paarrthhh Birla, Dariia Porechna, Dr. Chen Feng &middot; EternaX Labs</div></div>
+  <div class="cover-meta-item"><div class="cover-meta-label">Published</div><div class="cover-meta-value"><time datetime="2026-05-28">May 28, 2026</time></div></div>
+  <div class="cover-meta-item"><div class="cover-meta-label">Audience</div><div class="cover-meta-value">Boards, Risk Committees, Tokenization Teams, Stablecoin Issuers, Custodians, VCs</div></div>
+</div>
+<div class="pull-quote" style="margin-top:1.5rem;">The ~$300 trillion global securities, deposits, and fund market is beginning its migration to blockchain infrastructure. The $26.7 billion already on chain is not the story. It is the proof that rail decisions are being made right now, on classical cryptography that NIST has proposed to deprecate by 2030. This report maps where those decisions are being made, which institutions are making them, and why new issuance should be PQ-native from day one.</div>
+
+<div class="toc">
+<div class="toc-title">Report Index</div>
+<div class="toc-grid">
+<a href="#exposure-thesis"><span>01</span>The Exposure Thesis: Institutional Crypto on Classical Rails</a>
+<a href="#institutional-map"><span>02</span>Institutional Exposure Map: 20+ Named Institutions</a>
+<a href="#chain-map"><span>03</span>Chain Exposure: Ethereum, Canton, Solana, Stellar, XRPL</a>
+<a href="#risk-sources"><span>04</span>Nine Problem Sources Across Institutional Crypto</a>
+<a href="#pilots"><span>05</span>Top 10 Institutional Pilots at Post-Quantum Risk</a>
+<a href="#legacy-vs-new"><span>06</span>Legacy Exposure vs New Issuance</a>
+<a href="#distribution-advantage"><span>07</span>PQ-Native as Distribution Advantage: Why EternaX</a>
+<a href="#faq"><span>08</span>Post-Quantum Risk FAQ</a>
+<a href="#authors"><span>09</span>Authors and Contact</a>
+</div>
+<p style="font-size:0.78rem; color:var(--text-muted); margin:0.75rem 0 0;">If you have 2 minutes: read the <a href="#key-findings" style="color:var(--brand);">Key Findings</a>. If you have 10 minutes: find your institution in <a href="#institutional-map" style="color:var(--brand);">Section 2</a>. If you are evaluating a new issuance decision: go to <a href="#legacy-vs-new" style="color:var(--brand);">Section 6</a>.</p>
+</div>
+</div>
+</header>
+
+<!-- SECTION 1: THE EXPOSURE THESIS -->
+<section id="exposure-thesis">
+<div class="container">
+<h2>1. The Exposure Thesis: Institutional Crypto on Classical Rails</h2>
+
+<div class="hero-line">Do not issue tomorrow's institutional assets onto yesterday's cryptography.</div>
+
+<div class="stats-grid">
+<div class="stat-card">
+<div class="stat-number">~$300T</div>
+<div class="stat-label">The global securities, deposits, and fund market moving toward blockchain rails. The infrastructure chosen today will carry this value for decades.</div>
+</div>
+<div class="stat-card">
+<div class="stat-number">$26.7B+</div>
+<div class="stat-label">Already on chain. $10B in tokenized Treasuries alone. These are not pilots. These are production rail decisions being made on classical cryptography.</div>
+</div>
+<div class="stat-card">
+<div class="stat-number">20+</div>
+<div class="stat-label">Named institutions mapped in this report. Zero have disclosed end-to-end post-quantum migration plans.</div>
+</div>
+<div class="stat-card">
+<div class="stat-number">90%</div>
+<div class="stat-label">Throughput loss confirmed on Solana under PQ migration. Project Eleven and Solana Foundation, April 2026.</div>
+</div>
+<div class="stat-card">
+<div class="stat-number">$0</div>
+<div class="stat-label">Migration debt on day one of PQ-native issuance. New issuance is a choice, not a retrofit.</div>
+</div>
+</div>
+
+<p>The ~$300 trillion tokenization opportunity is not arriving someday. It is arriving now, and it is choosing its rails. Over $317 billion in stablecoins and $36 billion in tokenized real-world assets already sit on blockchain infrastructure that NIST has proposed to deprecate by 2030. The $26.7 billion on chain today is not the risk. It is the template. Every rail decision, every pilot, every collateral framework, and every chain expansion being made today will determine the infrastructure that carries the next $300 trillion. The risk is not only quantum theft. It is locking the largest asset migration in financial history onto cryptography with a published expiration date.</p>
+
+<p>PQ-native infrastructure delivers three advantages simultaneously. <strong>Security:</strong> protects authorization, custody, mint/burn, bridges, settlement, and collateral from future quantum migration risk. <strong>Privacy:</strong> protects institutional flows, treasury movements, and counterparty behavior from store-now-decrypt-later attacks. <strong>Distribution:</strong> differentiates new issuance in a crowded tokenization market where every issuer competes on yield, liquidity, compliance, brand, and trust.</p>
+
+<div class="callout">
+<p class="callout-title">Privacy Is a Post-Quantum Problem</p>
+<p>Post-quantum risk extends beyond asset theft. It is about <strong>privacy durability</strong>. Public chains expose every institutional flow permanently. But private and permissioned ledgers create a more dangerous illusion: they promise confidentiality through access controls and classical encryption, not through quantum-durable cryptography. When the keys protecting that privacy layer break, every historical transaction becomes retroactively visible. Institutions that assumed confidentiality and traded, settled, and collateralized accordingly face retroactive exposure of all flows. Privacy-by-policy is not privacy-by-cryptography. Harvest-now-decrypt-later attacks are already active. The data being collected today will be readable when quantum capability arrives.</p>
+</div>
+
+<h3>Why Now: Five Forcing Functions</h3>
+<table class="forcing-table">
+<thead><tr><th>Date</th><th>Signal</th><th>Implication</th></tr></thead>
+<tbody>
+<tr><td>Mar 30, 2026</td><td>Google Quantum AI compressed the qubit threshold from ~20M to fewer than 500,000 physical qubits.</td><td>The "we have decades" planning heuristic is no longer defensible.</td></tr>
+<tr><td>Apr 2026</td><td>Project Eleven and the Solana Foundation confirmed ~90% TPS loss under PQ migration on a live testnet.</td><td>Quantum-safe Solana is not commercially viable today.</td></tr>
+<tr><td>Jan 2027</td><td>NSA CNSA 2.0 deadline: all new national security systems must be quantum-safe.</td><td>Federal compliance pressure flows into institutional counterparties.</td></tr>
+<tr><td>2026</td><td>FBI, NIST, and CISA jointly designated the "Year of Quantum Security."</td><td>Regulatory awareness is now institutional awareness.</td></tr>
+<tr><td>2030</td><td>NIST proposed deprecation of ECDSA and EdDSA. These are the exact algorithms securing every major blockchain.</td><td>Every chain in production today runs on cryptography with a published expiration date.</td></tr>
+</tbody>
+</table>
+
+<div class="findings" id="key-findings">
+<h3 style="margin-top:0;">Key Findings</h3>
+<ol>
+<li>The single biggest institutional PQ risk is <strong>control-plane key exposure</strong>: issuer admin keys, transfer-agent permissions, oracle signer sets, and bridge attestations. Not holder-wallet theft.</li>
+<li>Public chains leak institutional treasury behavior, collateral positions, and counterparty timing. <strong>Privacy is a PQ problem</strong>, not a separate concern.</li>
+<li>Private DLT reduces public visibility but does not deliver post-quantum security. <strong>Permissioned does not mean quantum-safe.</strong></li>
+<li>Every new stablecoin, tokenized fund, RWA, collateral pilot, or chain expansion is a <strong>rail-selection decision</strong> being made today.</li>
+<li>PQ-native issuance is not only safer. It is a <strong>distribution advantage</strong> in a crowded market.</li>
+</ol>
+</div>
+
+<p><strong>Legacy exposure</strong> is a migration problem: map it, contain it, harden it, plan for migration. <strong>New issuance</strong> is a choice: every new product can either create fresh migration debt or avoid it from day one. The rest of this report maps both.</p>
+
+<div class="pull-quote">The assets are regulated. The rails are classical. New issuance is the decision.</div>
+
+<p class="section-closer">Post-quantum risk is no longer a science problem. It is a financial-infrastructure design problem.</p>
+</div>
+</section>
+
+<!-- SECTION 2: INSTITUTIONAL EXPOSURE MAP -->
+<section id="institutional-map">
+<div class="container">
+<h2>2. Institutional Exposure Map: BlackRock, Circle, Franklin, Goldman, J.P. Morgan and 20+ Institutions</h2>
+<p>This table maps every major institution's live crypto activity to its post-quantum and privacy exposure. Every row is searchable, shareable, and personally relevant. If your institution appears below, your product carries cryptographic migration debt.</p>
+
+<h3>How Post-Quantum Risk Works: The Causal Chain</h3>
+<p>Every row in the table below follows the same logic. Read left to right:</p>
+
+<div class="risk-chain">
+<div class="risk-chain-step">
+<div class="risk-chain-num">Step 1</div>
+<div class="risk-chain-title">Your Product</div>
+<div class="risk-chain-detail">A tokenized fund, stablecoin, collateral rail, or settlement system your institution operates.</div>
+</div>
+<div class="risk-chain-step">
+<div class="risk-chain-num">Step 2</div>
+<div class="risk-chain-title">Lives on a Chain</div>
+<div class="risk-chain-detail">Ethereum, Solana, Stellar, Canton, XRPL, or another chain/ledger that carries the product.</div>
+</div>
+<div class="risk-chain-step">
+<div class="risk-chain-num">Step 3</div>
+<div class="risk-chain-title">Uses Classical Crypto</div>
+<div class="risk-chain-detail">That chain uses secp256k1, Ed25519, BLS, or other classical signatures. These are the algorithms NIST plans to deprecate.</div>
+</div>
+<div class="risk-chain-step">
+<div class="risk-chain-num">Step 4</div>
+<div class="risk-chain-title">Quantum Breaks It</div>
+<div class="risk-chain-detail">Shor's algorithm breaks these signatures. Google cut the qubit requirement to &lt;500K. The timeline is compressing.</div>
+</div>
+<div class="risk-chain-step">
+<div class="risk-chain-num">Step 5</div>
+<div class="risk-chain-title">Your Asset Is Exposed</div>
+<div class="risk-chain-detail">Admin keys, holder wallets, bridges, oracles, custody, and collateral on that chain all inherit the vulnerability.</div>
+</div>
+</div>
+
+<h3>Which Chain Uses Which Vulnerable Primitive?</h3>
+<p>This is why your product is exposed. Every chain below uses at least one classical signature algorithm that quantum computers will break.</p>
+
+<table class="primitive-table">
+<thead><tr><th>Chain</th><th>Vulnerable Primitive</th><th>What It Protects</th><th>What Breaks Under Quantum Attack</th></tr></thead>
+<tbody>
+<tr><td><strong>Ethereum</strong></td><td><code>secp256k1</code> (wallets), <code>BLS</code> (consensus), <code>KZG</code> (data availability)</td><td>Every wallet, every validator, every rollup proof</td><td>Wallet theft, consensus manipulation, data availability compromise</td></tr>
+<tr><td><strong>Canton</strong></td><td>Configurable (classical by default), external KMS/HSM</td><td>Node authentication, contract execution, participant keys, inter-node encryption</td><td>Operator impersonation, contract manipulation, retroactive exposure of all historical flows when encryption keys break. Privacy collapses.</td></tr>
+<tr><td><strong>Solana</strong></td><td><code>Ed25519</code></td><td>Every wallet, every validator, every program signer</td><td>Wallet theft, validator impersonation, program authority hijack</td></tr>
+<tr><td><strong>Stellar</strong></td><td><code>Ed25519</code></td><td>Every account, every validator in the FBA consensus</td><td>Account takeover, consensus disruption</td></tr>
+<tr><td><strong>XRPL</strong></td><td><code>Ed25519</code> or <code>secp256k1</code></td><td>Every account, every validator, native DEX orders</td><td>Account theft, order manipulation</td></tr>
+<tr><td><strong>Base / Arbitrum / L2s</strong></td><td><code>secp256k1</code> (inherited from Ethereum)</td><td>Every wallet, sequencer, bridge signer</td><td>Wallet theft, sequencer manipulation, bridge compromise</td></tr>
+<tr><td><strong>Avalanche / Aptos</strong></td><td><code>secp256k1</code> / <code>Ed25519</code></td><td>Wallets, validators, smart contracts</td><td>Same pattern: wallet theft, validator compromise</td></tr>
+<tr><td><strong>Private DLT (GS DAP, Kinexys, Swift)</strong></td><td>Classical (typically not disclosed)</td><td>Node identity, KMS, admin operations, legal records</td><td>Operator impersonation, admin key compromise, migration debt</td></tr>
+<tr class="row-green"><td><strong>EternaX</strong></td><td>SPHINCS+ (NIST FIPS 205) + SILMARILS. Hash-only. Zero classical primitives.</td><td>Every wallet, validator, admin key, bridge, oracle. PQ-native from genesis.</td><td>Nothing. No classical primitives to break. ~2% TPS cost. Migration debt: zero.</td></tr>
+</tbody>
+</table>
+
+<h3>Summary: Every Institution, Every Product, Every Risk Score</h3>
+<p>Scan the table below to find your institution. The cards that follow go deeper on the highest-risk clusters.</p>
+
+<div class="table-wrap">
+<table class="compact-table">
+<thead>
+<tr><th>Institution</th><th>Product</th><th>Value</th><th>Chain</th><th>Q Risk</th><th>Verdict</th></tr>
+</thead>
+<tbody>
+<tr><td class="inst-name">BlackRock / Securitize</td><td>BUIDL</td><td>~$2.5B</td><td>Ethereum, multichain</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Largest single PQ dependency cluster. Reserve asset for OUSG, USDtb.</td></tr>
+<tr><td class="inst-name">Circle / Hashnote</td><td>USYC</td><td>$313M</td><td>Base, Canton, Ethereum, NEAR, Solana</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Five-chain exposure. Two-token model amplifies bridge and oracle risk.</td></tr>
+<tr><td class="inst-name">Franklin Templeton</td><td>BENJI / FOBXX</td><td>$825M</td><td>9 chains: Stellar, Polygon, Arbitrum, Avalanche, Aptos, Base, Ethereum, Solana, BNB</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Nine public chains. Ed25519 + secp256k1. Centralized TA override.</td></tr>
+<tr><td class="inst-name">Franklin Templeton</td><td>iBENJI</td><td>$1.56B</td><td>Public blockchain</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Largest Franklin product. Chain-specific risk not fully disclosed.</td></tr>
+<tr><td class="inst-name">WisdomTree</td><td>WTGXX</td><td>$951M</td><td>Stellar, Ethereum</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Ed25519 + secp256k1. Migration requires fund admin coordination.</td></tr>
+<tr><td class="inst-name">Superstate</td><td>USTB + USCC</td><td>$988M + $269M</td><td>Ethereum, Solana, Plume</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Regulated fund integrated into DeFi lending. Compounds issuance + lending risk.</td></tr>
+<tr><td class="inst-name">Ondo</td><td>OUSG / USDY</td><td>Backed by BUIDL</td><td>Ethereum, XRPL</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Stacked tokenization: OUSG backed by BUIDL, used as sole collateral on Flux.</td></tr>
+<tr><td class="inst-name">VanEck / Securitize</td><td>VBILL</td><td>$59M</td><td>Securitize multichain, Wormhole</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Bridge-first risk. Wormhole attestation is the weakest link.</td></tr>
+<tr><td class="inst-name">Janus Henderson</td><td>JTRSY</td><td>$970M</td><td>Centrifuge, LayerZero</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Bridge-layer risk via LayerZero cross-chain expansion.</td></tr>
+<tr><td class="inst-name">Apollo / Securitize</td><td>ACRED</td><td>Not disclosed</td><td>6 chains: Aptos, Avalanche, Ethereum, Ink, Polygon, Solana</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Six-chain exposure. Leveraged RWA strategy on Morpho.</td></tr>
+<tr><td class="inst-name">UBS</td><td>uMINT</td><td>Not disclosed</td><td>Ethereum</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>G-SIB on public chain. Bank-grade migration coordination required.</td></tr>
+<tr><td class="inst-name">SG-FORGE</td><td>EURCV</td><td>Not disclosed</td><td>Ethereum, Solana, XRPL, Stellar</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>MiCA stablecoin on four vulnerable chains.</td></tr>
+<tr><td class="inst-name">State Street / Galaxy</td><td>SWEEP</td><td>Launching May 2026</td><td>Solana, Stellar, Ethereum planned</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Brand-new product on rails with 90% PQ throughput loss.</td></tr>
+<tr><td class="inst-name">Ripple</td><td>RLUSD</td><td>Live</td><td>XRPL, Ethereum, Wormhole NTT</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Stablecoin + prime brokerage + bridge expansion.</td></tr>
+<tr><td class="inst-name">PayPal / Paxos</td><td>PYUSD</td><td>Live</td><td>Ethereum, Solana, Arbitrum</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Consumer stablecoin on classical rails.</td></tr>
+<tr><td class="inst-name">Anchorage</td><td>USDtb reserves</td><td>Reserves in BUIDL</td><td>Bank + BUIDL chain</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Stacked: stablecoin admin keys on top of BUIDL reserve dependency.</td></tr>
+<tr><td class="inst-name">J.P. Morgan</td><td>Kinexys</td><td>&gt;$1.5T processed</td><td>Private DLT</td><td><span class="risk-badge risk-badge-3">3/5</span></td><td>Not public-chain theft. Control-plane and KMS migration risk.</td></tr>
+<tr><td class="inst-name">Goldman / BNY</td><td>GS DAP mirrors</td><td>Not disclosed</td><td>Private permissioned</td><td><span class="risk-badge risk-badge-3">3/5</span></td><td>Heaviest migration/legal debt. Opacity in cryptographic stack.</td></tr>
+<tr><td class="inst-name">Std Chartered / OKX</td><td>BUIDL collateral</td><td>Not disclosed</td><td>Off-exchange custody</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>First G-SIB-backed tokenized collateral. Concentrated admin keys.</td></tr>
+<tr><td class="inst-name">Binance / Ceffu</td><td>BUIDL off-exchange</td><td>Not disclosed</td><td>Off-exchange, BNB Chain</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Off-exchange custody keys on classical rails.</td></tr>
+<tr><td class="inst-name">Deribit</td><td>USYC margin</td><td>Not disclosed</td><td>Venue system</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Yield-bearing derivatives collateral. Haircut widening risk.</td></tr>
+<tr><td class="inst-name">DTCC</td><td>Collateral AppChain</td><td>Pilot Q4 2026</td><td>AppChain</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Pilot on vulnerable rails becomes production default.</td></tr>
+<tr><td class="inst-name">Broadridge</td><td>DLT Repo</td><td>$362B ADV</td><td>DLT / Canton</td><td><span class="risk-badge risk-badge-4">4/5</span></td><td>Hundreds of billions daily. Migration debt at infrastructure scale.</td></tr>
+<tr><td class="inst-name">Aave</td><td>Horizon RWA</td><td>TVL $604M</td><td>Ethereum</td><td><span class="risk-badge risk-badge-5">5/5</span></td><td>Oracle/NAV risk. Liquidation on public chain. Permissioned collateral, public rails.</td></tr>
+</tbody>
+</table>
+</div>
+
+<h3>Highest-Risk Institutions: Detailed Cards</h3>
+<div class="inst-grid">
+
+<div class="inst-card">
+<div class="inst-card-header"><span class="inst-card-name">BlackRock / Securitize</span><span class="risk-badge risk-badge-5">PQ 5/5</span></div>
+<div class="inst-card-product">BUIDL tokenized Treasury/MMF &middot; ~$2.5B</div>
+<div class="inst-card-meta"><strong>Chain:</strong> Ethereum + multichain via Securitize &middot; <strong>Primitives:</strong> secp256k1 &middot; <strong>Partners:</strong> OKX, Binance, Hidden Road, Komainu, Ondo, Anchorage</div>
+<div class="inst-card-risk"><strong>Why exposed:</strong> Concentrated admin/TA keys at Securitize control mint, burn, whitelist across all share classes. Downstream reserve asset for OUSG and USDtb means a control-plane compromise propagates across products and venues. No PQ migration disclosed. <strong>New issuance:</strong> Future share classes should evaluate PQ-native rails.</div>
+</div>
+
+<div class="inst-card">
+<div class="inst-card-header"><span class="inst-card-name">Circle / Hashnote</span><span class="risk-badge risk-badge-5">PQ 5/5</span></div>
+<div class="inst-card-product">USYC tokenized MMF &middot; $313M</div>
+<div class="inst-card-meta"><strong>Chain:</strong> Base, Canton, Ethereum, NEAR, Solana &middot; <strong>Primitives:</strong> secp256k1, Ed25519 &middot; <strong>Collateral:</strong> Deribit cross-margin</div>
+<div class="inst-card-risk"><strong>Why exposed:</strong> Five chains, each using classical signatures. Two-token model (USYC + USDC redemption) creates interoperability dependencies on Circle attestation services. <strong>New issuance:</strong> New collateral rails and chain expansions should be PQ-native.</div>
+</div>
+
+<div class="inst-card">
+<div class="inst-card-header"><span class="inst-card-name">Franklin Templeton</span><span class="risk-badge risk-badge-5">PQ 5/5</span></div>
+<div class="inst-card-product">BENJI / FOBXX &middot; $825M</div>
+<div class="inst-card-meta"><strong>Chain:</strong> 9 networks (Stellar, Polygon, Arbitrum, Avalanche, Aptos, Base, Ethereum, Solana, BNB) &middot; <strong>Primitives:</strong> Ed25519, secp256k1</div>
+<div class="inst-card-risk"><strong>Why exposed:</strong> Transfer agent maintains centralized override across nine public chains. Each new chain deployment compounds migration debt. Textbook case of public-chain contact + centralized administrative control. <strong>New issuance:</strong> Treat each chain expansion as a new issuance decision.</div>
+</div>
+
+<div class="inst-card">
+<div class="inst-card-header"><span class="inst-card-name">Ondo</span><span class="risk-badge risk-badge-5">PQ 5/5</span></div>
+<div class="inst-card-product">OUSG / Flux &middot; Backed by BUIDL</div>
+<div class="inst-card-meta"><strong>Chain:</strong> Ethereum, XRPL &middot; <strong>Primitives:</strong> secp256k1, Ed25519 &middot; <strong>Collateral:</strong> Sole collateral on Flux</div>
+<div class="inst-card-risk"><strong>Why exposed:</strong> Stacked tokenization: OUSG is backed by BUIDL, then used as sole collateral on Flux. One classical control-plane layer secures another. Breaking the base layer breaks the borrowing layer. <strong>New issuance:</strong> Stacked tokenization demands PQ-native rails at the base.</div>
+</div>
+
+<div class="inst-card">
+<div class="inst-card-header"><span class="inst-card-name">Superstate</span><span class="risk-badge risk-badge-5">PQ 5/5</span></div>
+<div class="inst-card-product">USTB ($988M) + USCC ($269M)</div>
+<div class="inst-card-meta"><strong>Chain:</strong> Ethereum, Solana, Plume &middot; <strong>DeFi:</strong> Aave Horizon integration ($66.5M USTB)</div>
+<div class="inst-card-risk"><strong>Why exposed:</strong> Sits at the boundary of regulated fund and DeFi-collateral primitive. Combines public-chain issuance risk with onchain borrowing interface risk. <strong>New issuance:</strong> DeFi collateral integrations on classical rails multiply migration debt.</div>
+</div>
+
+<div class="inst-card">
+<div class="inst-card-header"><span class="inst-card-name">J.P. Morgan</span><span class="risk-badge risk-badge-3">PQ 3/5</span></div>
+<div class="inst-card-product">Kinexys &middot; &gt;$1.5T processed</div>
+<div class="inst-card-meta"><strong>Chain:</strong> Private bank-led DLT &middot; <strong>Primitives:</strong> Classical enterprise crypto (not disclosed)</div>
+<div class="inst-card-risk"><strong>Why exposed:</strong> Not public-chain theft risk. Control-plane-heavy: bank admin keys, KMS, legal continuity across tokenized deposits, GBP blockchain accounts, and interoperability. <strong>New issuance:</strong> New settlement corridors should test PQ-native rails.</div>
+</div>
+
+<div class="inst-card">
+<div class="inst-card-header"><span class="inst-card-name">Goldman / BNY</span><span class="risk-badge risk-badge-3">PQ 3/5</span></div>
+<div class="inst-card-product">GS DAP tokenized MMF mirrors</div>
+<div class="inst-card-meta"><strong>Chain:</strong> GS DAP private permissioned &middot; <strong>Partner:</strong> BNY Digital Assets</div>
+<div class="inst-card-risk"><strong>Why exposed:</strong> Private mirror ledger. Lower public-chain theft, but heaviest migration/legal debt: re-papering across banks, funds, client books, custody, and legacy systems. Exact crypto primitives not disclosed. <strong>New issuance:</strong> Private-ledger modernization can start with PQ-native pilots.</div>
+</div>
+
+<div class="inst-card">
+<div class="inst-card-header"><span class="inst-card-name">Std Chartered / OKX</span><span class="risk-badge risk-badge-4">PQ 4/5</span></div>
+<div class="inst-card-product">BUIDL yield-bearing collateral framework</div>
+<div class="inst-card-meta"><strong>Chain:</strong> Off-exchange SC custody, OKX venue &middot; <strong>Partners:</strong> BlackRock, Brevan Howard</div>
+<div class="inst-card-risk"><strong>Why exposed:</strong> First G-SIB-backed off-exchange tokenized collateral. Market choosing credit/legal structure first, composability second. Concentrated admin/custody keys and legal close-out complexity. <strong>New issuance:</strong> New collateral programs should test PQ-native custody and signing.</div>
+</div>
+
+</div>
+
+<h3>Dependency Clusters: Where Risk Concentrates</h3>
+
+<div class="callout">
+<p class="callout-title">BUIDL: The Single Largest PQ Dependency Cluster</p>
+<p>BUIDL is simultaneously a fund wrapper, a transfer-agent stack, public-chain and multichain smart contracts, off-exchange legal agreements, and downstream reserve assets for OUSG and USDtb. A control-plane compromise at the Securitize or issuer-admin level propagates across OKX, Binance, Hidden Road, Komainu, Ondo, and Anchorage.</p>
+</div>
+
+<div class="callout">
+<p class="callout-title">Stacked Tokenization: OUSG/Flux and USDtb/BUIDL</p>
+<p>OUSG is backed by BUIDL, then used as sole collateral on Flux. USDtb reserves are "almost entirely" in BUIDL. One classical control-plane layer secures another. Breaking the base layer breaks the borrowing layer and the stablecoin layer above it.</p>
+</div>
+
+<div class="callout">
+<p class="callout-title">Multichain Bridge Exposure: VBILL, JTRSY, RLUSD</p>
+<p>VBILL relies on Wormhole attestation. JTRSY plans LayerZero cross-chain expansion. RLUSD is expanding to L2s via Wormhole NTT. Bridge and messaging signer sets become first-order PQ attack surfaces. Even if base chains survive, cross-chain attestation compromise is critical.</p>
+</div>
+
+<div class="callout">
+<p class="callout-title">Private-DLT Migration Debt: GS DAP, Kinexys, Canton, Swift</p>
+<p>Private ledgers reduce public-holder theft risk but face the heaviest migration debt: re-keying across banks, funds, client books, custody, contractual governance, and legacy systems. Migration that breaks legal continuity is commercially useless.</p>
+</div>
+
+<h3>Product-Archetype PQ Exposure Matrix</h3>
+<div class="table-wrap">
+<table>
+<thead><tr><th>Product Archetype</th><th>PQ Risk</th><th>Verdict</th></tr></thead>
+<tbody>
+<tr><td>Public-chain tokenized MMF on Ethereum/EVM</td><td><span class="risk-5">5/5</span></td><td>Full classical stack: wallet, admin, contract, consensus, bridge, oracle, collateral, migration. Highest combined exposure.</td></tr>
+<tr><td>Public-chain MMF on Solana/Stellar</td><td><span class="risk-4">4/5</span></td><td>Ed25519 quantum-vulnerable. Simpler contract surface than EVM, but admin concentration unchanged.</td></tr>
+<tr><td>Multichain fund with bridge layer</td><td><span class="risk-5">5/5</span></td><td>Bridge and messaging risk becomes first-order. Cross-chain attestation is the weakest link.</td></tr>
+<tr><td>Permissioned DeFi RWA lending</td><td><span class="risk-5">5/5</span></td><td>Liquidation depends on oracle/NAV freshness. Smart-contract risk plus permissioned collateral.</td></tr>
+<tr><td>CeFi off-exchange collateral / triparty</td><td><span class="risk-4">4/5</span></td><td>Lower base-chain code risk, but concentrated admin/custody keys and legal close-out complexity.</td></tr>
+<tr><td>Stablecoin backed by tokenized MMFs</td><td><span class="risk-5">5/5</span></td><td>Stacked dependency: stablecoin admin keys plus reserve-asset admin/oracle/bridge dependence.</td></tr>
+<tr><td>Private permissioned mirrors</td><td><span class="risk-3">3/5</span></td><td>Less public-holder theft, but concentrated operator/admin/KMS and legal migration debt dominate.</td></tr>
+<tr><td>Tokenized deposits / payments rails</td><td><span class="risk-3">3/5</span></td><td>Control-plane-heavy and dependent on KMS, bank admin keys, and legal continuity.</td></tr>
+<tr><td>Private DLT with selective privacy</td><td><span class="risk-3">3/5</span></td><td>PQ migration complicated by permissioned memberships, custom crypto stacks, contractual governance.</td></tr>
+<tr><td>Settlement / collateral infrastructure</td><td><span class="risk-4">4/5</span></td><td>Less about user wallets, more about institutional concentration and migration/legal debt at infrastructure scale.</td></tr>
+</tbody>
+</table>
+</div>
+
+<h3>Product-Archetype Privacy Exposure Matrix</h3>
+<div class="table-wrap">
+<table>
+<thead><tr><th>Product Archetype</th><th>Privacy Risk</th><th>Verdict</th></tr></thead>
+<tbody>
+<tr><td>Public Ethereum/EVM tokenized funds</td><td><span class="risk-5">5/5</span></td><td>Transfers, collateral postings, liquidations widely visible. MEV and order-flow leakage around collateral adjustments.</td></tr>
+<tr><td>Public Solana/Stellar/XRPL stablecoin rails</td><td><span class="risk-4">4/5</span></td><td>Lower MEV intensity in some cases, but transparency and future decryption/graphing risk remain strong.</td></tr>
+<tr><td>Permissioned DeFi RWA markets</td><td><span class="risk-4">4/5</span></td><td>Borrowers may be permissioned, but positions, contracts, and liquidation flows remain inspectable on public chains.</td></tr>
+<tr><td>CeFi triparty / off-exchange collateral</td><td><span class="risk-3">3/5</span></td><td>Lower public leakage, but institutions overestimate confidentiality when custodian, exchange, and regulator visibility remains extensive.</td></tr>
+<tr><td>Private token mirrors and bank ledgers</td><td><span class="risk-3">3/5</span></td><td>The danger is assuming permissioned privacy equals cryptographic privacy. It usually does not.</td></tr>
+<tr><td>Canton-style selective privacy</td><td><span class="risk-4">4/5</span></td><td>Privacy depends on classical encryption, not quantum-durable cryptography. When keys break, all historical flows become retroactively visible. Divulgence documented. HNDL active.</td></tr>
+<tr><td>Stablecoin reserve stacks</td><td><span class="risk-4">4/5</span></td><td>Reserve movements reveal strategic treasury behavior. Store-now-decrypt-later creates latent future disclosure risk.</td></tr>
+<tr><td>Payments / tokenized deposit systems</td><td>2/5</td><td>Better operational confidentiality, but privacy depends on operator trust and eventual cryptographic migration.</td></tr>
+</tbody>
+</table>
+</div>
+
+<p class="section-closer">If your product touches a classical chain, your asset has cryptographic migration debt attached to it.</p>
+</div>
+</section>
+
+<!-- SECTION 3: CHAIN AND LEDGER EXPOSURE MAP -->
+<section id="chain-map">
+<div class="container">
+<h2>3. Chain and Ledger Exposure Map: Ethereum, Canton, Solana, Stellar, XRPL and More</h2>
+<p>Every chain below except EternaX relies on classical cryptographic assumptions today. None of the incumbent chains has completed a post-quantum migration. "Value exposed" means the approximate value of products in this report that touch that chain, not the exact amount residing on it. Many products are multichain, so rows are not additive.</p>
+
+<div class="table-wrap">
+<table>
+<thead>
+<tr><th>Chain / Ledger</th><th>Institutions / Products</th><th>Value Exposed</th><th>Signature Primitives</th><th>PQ Migration</th><th>PQ Risk</th><th>Privacy Risk</th><th>Verdict</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Ethereum</strong></td><td>BUIDL, USYC, BENJI, USTB, USCC, OUSG, ACRED, RLUSD, PYUSD, EURCV, uMINT, SWEEP</td><td>&gt;$5B</td><td>secp256k1 (EOA), BLS (consensus), KZG (roadmap)</td><td>Active research, multi-year roadmap, no production migration. ~84% TPS loss modeled.</td><td><span class="risk-5">5/5</span></td><td><span class="risk-5">5/5</span></td><td>Highest-value exposure. ~84% throughput loss under PQ. Rich metadata leakage. Active research does not equal institutional readiness.</td></tr>
+<tr><td><strong>Canton</strong></td><td>USYC, Broadridge DLR ($362B ADV), Goldman/BNY institutional workflows</td><td>Significant institutional workflow exposure</td><td>Configurable crypto (classical by default), external KMS/HSM</td><td>None disclosed. ~88% TPS loss modeled under Dilithium-class PQ migration.</td><td><span class="risk-4">4/5</span></td><td><span class="risk-4">4/5</span></td><td>Privacy collapses when keys break. All historical flows become retroactively visible. Divulgence to non-stakeholders explicitly documented. HNDL attacks already active. Privacy-by-policy is not privacy-by-cryptography.</td></tr>
+<tr><td><strong>Solana</strong></td><td>USYC, USTB, USCC, PYUSD, EURCV, SWEEP</td><td>~$2.57B RWA</td><td>Ed25519</td><td>No mature PQ migration. 90% TPS loss confirmed live.</td><td><span class="risk-4">4/5</span></td><td><span class="risk-4">4/5</span></td><td>Ed25519 quantum-vulnerable. 90% throughput loss confirmed. Commercially unviable under PQ at current architecture.</td></tr>
+<tr><td><strong>Stellar</strong></td><td>BENJI, WTGXX, EURCV</td><td>~$1.8B products</td><td>Ed25519</td><td>No public PQ roadmap. ~90% TPS loss modeled.</td><td><span class="risk-4">4/5</span></td><td><span class="risk-3">3/5</span></td><td>Ed25519 quantum-vulnerable. ~90% throughput loss modeled. $1.8B+ in products with no disclosed migration path.</td></tr>
+<tr><td><strong>XRPL</strong></td><td>RLUSD, OUSG, EURCV</td><td>Not fully disclosed</td><td>Ed25519 or secp256k1</td><td>No public PQ roadmap</td><td><span class="risk-4">4/5</span></td><td><span class="risk-4">4/5</span></td><td>Public ledger with native DEX creating visible order/flow metadata. Growing institutional relevance.</td></tr>
+<tr><td><strong>Base / Arbitrum / BNB Chain / EVM L2s</strong></td><td>USYC, BENJI, VBILL, BUIDL classes, SWEEP</td><td>Material</td><td>Inherit secp256k1 from Ethereum</td><td>Optimism published PQ roadmap; broader L2 migration early</td><td><span class="risk-5">5/5</span></td><td><span class="risk-5">5/5</span></td><td>Inherit Ethereum's settlement assumptions plus sequencer/bridge metadata risk.</td></tr>
+<tr><td><strong>Aptos</strong></td><td>BENJI, ACRED</td><td>Not disclosed</td><td>Ed25519, secp256k1, passkeys/multikey</td><td>Flexible auth helps future options, no complete PQ posture</td><td><span class="risk-4">4/5</span></td><td><span class="risk-4">4/5</span></td><td>Account flexibility aids future migration, but no PQ deployment disclosed.</td></tr>
+<tr><td><strong>Avalanche</strong></td><td>BENJI, ACRED, KKR SKHC</td><td>Not disclosed</td><td>secp256k1 (AVM/EVM)</td><td>No public PQ path</td><td><span class="risk-4">4/5</span></td><td><span class="risk-4">4/5</span></td><td>Public chain. Cross-chain integrations matter more than base-layer privacy.</td></tr>
+<tr><td><strong>GS DAP</strong></td><td>BNY/Goldman tokenized MMF mirrors</td><td>Not public</td><td>Private permissioned, exact algorithms not disclosed</td><td>Lower public-chain risk, higher migration/legal debt</td><td><span class="risk-3">3/5</span></td><td><span class="risk-3">3/5</span></td><td>Classical encryption protects inter-node privacy. When those keys break, historical flows become retroactively visible. Same HNDL exposure as Canton. Concentrated operator control.</td></tr>
+<tr><td><strong>Swift shared ledger</strong></td><td>Tokenized deposits, interoperability</td><td>Flow-scale</td><td>Standards stack, crypto not fully exposed</td><td>Migration burden high: multi-party standardization</td><td><span class="risk-3">3/5</span></td><td><span class="risk-3">3/5</span></td><td>Classical encryption protects inter-bank messaging. HNDL applies. PQ migration requires coordination across 11,000+ institutions.</td></tr>
+<tr class="row-green"><td><strong>EternaX</strong></td><td>PQ-native issuance: stablecoins, RWAs, tokenized funds, collateral, settlement</td><td>Testnet live. Institutional pilots.</td><td>SPHINCS+ (NIST FIPS 205) + SILMARILS 160-byte. Hash-only. No pairings, no BLS, no KZG.</td><td>PQ-native from genesis. Zero migration debt. ~2% TPS loss. 50,000+ TPS, ~120ms finality.</td><td><span class="risk-0">0/5</span></td><td><span class="risk-0">0/5</span></td><td>The only EVM-compatible PQ-native L1. Auditable privacy. Validator-blind confidentiality. MEV-zero. No classical primitives to migrate. New issuance starts here.</td></tr>
+</tbody>
+</table>
+</div>
+
+<p class="section-closer">Every other chain in this table relies on classical cryptographic assumptions today. None has completed a post-quantum migration. One chain was built so migration is never needed.</p>
+</div>
+</section>
+
+<!-- SECTION 4: WHERE THE RISK LIVES -->
+<section id="risk-sources">
+<div class="container">
+<h2>4. Where Post-Quantum Risk Lives: Nine Problem Sources Across Institutional Crypto</h2>
+<p>Post-quantum risk decomposes into nine distinct problem sources. Generic claims are useless. Specific mapping is what boards need.</p>
+
+<h3>4.1 Holder-Wallet Key Risk</h3>
+<p>Every institutional wallet on Ethereum uses secp256k1. Every wallet on Solana, Stellar, and XRPL uses Ed25519. Both are vulnerable to Shor's algorithm. Google's March 2026 paper compressed the qubit requirement to fewer than 500,000. This affects every holder of BUIDL, USYC, BENJI, USTB, USCC, OUSG, RLUSD, PYUSD, EURCV, uMINT, and every other tokenized asset on these chains.</p>
+
+<h3>4.2 Admin-Key and Transfer-Agent Risk</h3>
+<p>This is the most economically dangerous exposure. Issuer admin keys control mint, burn, freeze, whitelist, upgrade, and redemption functions. Franklin's transfer agent can reverse and correct onchain transfers. Securitize manages BUIDL's multichain share classes. A single compromised admin key can affect every holder simultaneously. These keys are typically secp256k1 or Ed25519 with no disclosed PQ hardening.</p>
+
+<h3>4.3 Chain-Level Consensus and Finality Risk</h3>
+<p>Ethereum consensus uses BLS signatures. The Ethereum roadmap identifies BLS, KZG commitments, and ZK systems as quantum-sensitive. Solana, Stellar, XRPL, Avalanche, and Aptos all use classical signature schemes for validator and consensus operations. A consensus-level attack does not steal individual wallets; it undermines the finality guarantee that every institutional settlement depends on.</p>
+
+<h3>4.4 Bridge and Cross-Chain Messaging Risk</h3>
+<p>Wormhole, CCIP, LayerZero, Axelar, and native bridges all rely on classical signer sets for message attestation. VBILL uses Wormhole. JTRSY plans LayerZero. RLUSD is expanding via Wormhole NTT. CCIP supports SWEEP. Even if both source and destination chains survive, a compromised bridge signer set can mint, redirect, or burn tokens in transit. Bridge risk is first-order for any multichain product.</p>
+
+<h3>4.5 Oracle and NAV-Feed Risk</h3>
+<p>Aave Horizon liquidations depend on oracle/NAV freshness. Chainlink NAVLink feeds VBILL and SWEEP pricing. Attestation signers, price-feed operators, and NAV publishers all use classical signatures. A manipulated oracle feed under quantum attack can trigger incorrect liquidations, mispriced collateral, or failed redemptions across permissioned lending markets.</p>
+
+<h3>4.6 Custody, MPC, and HSM Risk</h3>
+<p>Standard Chartered, Komainu, Ceffu, Anchorage, and BNY all provide institutional custody. MPC, multisig, and HSM architectures typically depend on classical primitives at the signing layer. Even when custody is segregated and institutionally governed, the underlying key material is quantum-vulnerable unless specifically migrated to PQ-safe schemes.</p>
+
+<h3>4.7 Collateral Repricing Risk</h3>
+<p>When the market begins to price quantum risk into collateral eligibility, haircuts widen. A tokenized MMF that today receives an 88% LTV on Aave Horizon may see that LTV reduced if the underlying chain's cryptographic rail is deemed compromised or migration-uncertain. Collateral eligibility withdrawal, haircut widening, and margin call acceleration are commercial consequences that precede any actual quantum attack.</p>
+
+<h3>4.8 Privacy Leakage and Store-Now-Decrypt-Later Risk</h3>
+<p>Public chains expose treasury movements, wallet balances, redemption behavior, collateral postings, liquidation events, counterparty timing, and market-maker flows. This data is being harvested now. Under store-now-decrypt-later, encrypted communications, key exchanges, and privacy-layer protections can be retroactively broken once quantum capability arrives. Privacy is a PQ problem, not a separate concern.</p>
+
+<h3>4.9 Private-DLT False Comfort</h3>
+<p>The most underestimated risk. Canton's privacy depends on classical encryption, not quantum-durable cryptography. When those keys break, privacy collapses completely: every historical flow becomes retroactively visible. Divulgence to non-stakeholders is documented. HNDL collection is already active. GS DAP's exact primitives are not disclosed. Swift operates on enterprise privacy with operator visibility. Privacy-by-policy is not privacy-by-cryptography.</p>
+
+<h3>What Happens When the Market Reprices Cryptographic Risk?</h3>
+
+<div class="pull-quote">The repricing does not begin when quantum computers arrive. It begins when the market opens the balance sheet.</div>
+
+<p>The commercial consequences arrive before any quantum computer breaks a key. <strong>Collateral eligibility withdrawal:</strong> venues and clearing firms adjust accepted collateral lists based on infrastructure risk assessments. <strong>Haircut widening:</strong> tokens on chains with no PQ roadmap receive worse collateral terms, reducing capital efficiency. <strong>Insurance and audit repricing:</strong> underwriters and auditors adjust risk models for quantum-exposed custody and settlement infrastructure. <strong>Institutional trust erosion:</strong> issuers without disclosed PQ roadmaps lose competitive position to issuers on PQ-native rails. The repricing does not begin when quantum computers arrive. It begins when the market opens the balance sheet.</p>
+
+<p class="section-closer">The weakest key in the control plane becomes the strongest reason your collateral gets repriced.</p>
+</div>
+</section>
+
+<!-- SECTION 5: TOP 10 INSTITUTIONAL PILOTS AT RISK -->
+<section id="pilots">
+<div class="container">
+<h2>5. Top 10 Institutional Crypto Pilots at Post-Quantum Risk</h2>
+<p>These are the highest-stakes institutional crypto pilots happening right now. Each one is not just a product launch. It is an architecture decision that will determine how the next tranche of the ~$300 trillion tokenization opportunity gets built. Each one is building on classical rails. Each one will harden into production. The window to influence architecture is during the pilot, not after.</p>
+
+<div class="pilot-card" id="pilot-dtcc">
+<div class="pilot-header"><h3 class="pilot-name" style="margin:0;font-size:0.95rem;">1. DTCC Collateral AppChain</span><span class="risk-badge risk-badge-5">Critical</h3></div>
+<div class="pilot-what">Tokenizing and mobilizing collateral across public and private networks. Going live Q4 2026. Collateral providers, triparty agents, custodians.</div>
+<div class="pilot-break"><strong>Where it breaks:</strong> Classical primitives for node identity, admin operations, and asset representations. Collateral tokens from public chains inherit secp256k1/Ed25519 exposure. Admin keys controlling collateral movement and settlement finality are classical.</div>
+<div class="pilot-verdict">If it launches on classical rails, every collateral flow routed through it inherits migration debt. Retrofitting the production collateral backbone of U.S. finance is orders of magnitude harder than getting the pilot right.</div>
+<div class="pilot-alt">EternaX alternative: PQ-native collateral tokenization, movement, and settlement with auditable privacy. Zero classical key dependency. Testnet-ready.</div>
+</div>
+
+<div class="pilot-card" id="pilot-sweep">
+<div class="pilot-header"><h3 class="pilot-name" style="margin:0;font-size:0.95rem;">2. State Street / Galaxy SWEEP Fund on Solana</span><span class="risk-badge risk-badge-5">Critical</h3></div>
+<div class="pilot-what">Brand-new onchain liquidity sweep fund launching May 2026 on Solana. Chainlink CCIP/NAVLink. PYUSD for 24/7 subscriptions. Ondo seed investment.</div>
+<div class="pilot-break"><strong>Where it breaks:</strong> Solana Ed25519. 90% TPS loss confirmed under PQ. CCIP oracle signers use classical keys. Fund admin keys on Solana are Ed25519. This is not legacy exposure. This is a new-issuance rail decision being made right now.</div>
+<div class="pilot-verdict">A new billion-dollar fund launching today on rails that are commercially unviable under PQ. The cost of choosing PQ-native now is near zero. The cost of migrating later is not.</div>
+<div class="pilot-alt">EternaX alternative: PQ-native sweep fund with ~2% TPS loss, EVM-compatible deployment, and auditable privacy for institutional flows.</div>
+</div>
+
+<div class="pilot-card" id="pilot-gsdap">
+<div class="pilot-header"><h3 class="pilot-name" style="margin:0;font-size:0.95rem;">3. Goldman / BNY GS DAP Tokenized MMF</span><span class="risk-badge risk-badge-4">High</h3></div>
+<div class="pilot-what">Phase one live since July 2025. BNY LiquidityDirect on Goldman's GS DAP. Mirrored tokenized MMF share classes. BNY as custodian and tokenization manager.</div>
+<div class="pilot-break"><strong>Where it breaks:</strong> Private permissioned ledger. Exact cryptographic primitives not disclosed. KMS/HSM on classical key material. Admin/operator keys concentrated. Migration requires re-papering across Goldman, BNY, fund structures, client books, and legacy systems.</div>
+<div class="pilot-verdict">This is the blueprint for how the largest banks will tokenize. Whatever GS DAP looks like in production becomes the template every bank copies. If the template is classical, every copy inherits the same migration debt.</div>
+<div class="pilot-alt">EternaX alternative: PQ-native tokenized MMF infrastructure with zero classical key dependency. Private, auditable, migration-free.</div>
+</div>
+
+<div class="pilot-card" id="pilot-swift">
+<div class="pilot-header"><h3 class="pilot-name" style="margin:0;font-size:0.95rem;">4. Swift Shared Ledger</span><span class="risk-badge risk-badge-4">High</h3></div>
+<div class="pilot-what">Blockchain-based shared ledger supporting tokenized deposits across banks in multiple regions. Live trials since 2025, MVP progress 2026.</div>
+<div class="pilot-break"><strong>Where it breaks:</strong> Multi-party standardization around classical crypto. Changing a Swift standard requires consensus across 11,000+ financial institutions. Classical encryption protects inter-bank messaging.</div>
+<div class="pilot-verdict">Standards are the hardest thing to change. A Swift standard built on classical crypto becomes the rails for global tokenized deposits. The standardization window is now.</div>
+<div class="pilot-alt">EternaX alternative: PQ-native interoperability standard for tokenized deposits. Standards built on quantum-durable crypto from day one.</div>
+</div>
+
+<div class="pilot-card" id="pilot-scokx">
+<div class="pilot-header"><h3 class="pilot-name" style="margin:0;font-size:0.95rem;">5. Standard Chartered / OKX / BlackRock BUIDL Collateral</span><span class="risk-badge risk-badge-4">High</h3></div>
+<div class="pilot-what">First G-SIB-backed off-exchange tokenized collateral framework. Live April 2026. BUIDL as yield-bearing trading collateral.</div>
+<div class="pilot-break"><strong>Where it breaks:</strong> BUIDL on Ethereum (secp256k1). Admin/TA keys at Securitize are classical. Standard Chartered custody KMS is classical. Legal close-out agreements reference classical chain state.</div>
+<div class="pilot-verdict">Market structure hardens fast. The first G-SIB collateral template becomes the default. Every subsequent bank-exchange collateral deal will copy this model. Getting PQ into the template now is infinitely easier than retrofitting after 10 banks copy it.</div>
+<div class="pilot-alt">EternaX alternative: PQ-native collateral custody and settlement. G-SIB-grade security without classical key exposure.</div>
+</div>
+
+<div class="pilot-card" id="pilot-broadridge">
+<div class="pilot-header"><h3 class="pilot-name" style="margin:0;font-size:0.95rem;">6. Broadridge DLT Repo on Canton</span><span class="risk-badge risk-badge-5">Critical</h3></div>
+<div class="pilot-what">Live. $362B average daily repo volume. $7.7T monthly. Connected to Canton ecosystem. The single largest DLT settlement system by volume.</div>
+<div class="pilot-break"><strong>Where it breaks:</strong> Canton uses classical crypto by default. ~88% TPS loss under PQ. Privacy collapses when keys break: all historical repo flows become retroactively visible. HNDL collection already active.</div>
+<div class="pilot-verdict">Hundreds of billions in daily settlement on classical DLT. Changing this requires coordinating across the entire institutional repo market. The architecture is already production.</div>
+<div class="pilot-alt">EternaX alternative: PQ-native repo settlement with auditable privacy that does not collapse when keys break. Zero retroactive exposure.</div>
+</div>
+
+<div class="pilot-card" id="pilot-aave">
+<div class="pilot-header"><h3 class="pilot-name" style="margin:0;font-size:0.95rem;">7. Aave Horizon RWA Market</span><span class="risk-badge risk-badge-5">Critical</h3></div>
+<div class="pilot-what">First institutional DeFi lending market. TVL $604M. Permissioned RWA collateral (USTB, USCC, VBILL) with open stablecoin lending. On Ethereum.</div>
+<div class="pilot-break"><strong>Where it breaks:</strong> Smart-contract risk on Ethereum. Oracle/NAV signers use classical keys. Liquidation logic depends on oracle freshness. All positions and liquidation events are publicly visible. Zero privacy.</div>
+<div class="pilot-verdict">This is the prototype for institutional DeFi. Whatever Aave Horizon looks like becomes what regulators and risk committees evaluate. If the prototype runs on classical rails with public transparency, that becomes the benchmark.</div>
+<div class="pilot-alt">EternaX alternative: PQ-native institutional DeFi with auditable privacy, PQ-safe oracle attestation, and MEV-zero execution.</div>
+</div>
+
+<div class="pilot-card" id="pilot-rlusd">
+<div class="pilot-header"><h3 class="pilot-name" style="margin:0;font-size:0.95rem;">8. Ripple / Hidden Road RLUSD Prime Brokerage</span><span class="risk-badge risk-badge-4">High</h3></div>
+<div class="pilot-what">RLUSD as collateral across multi-asset prime brokerage. Cross-margining between crypto and traditional finance instruments.</div>
+<div class="pilot-break"><strong>Where it breaks:</strong> RLUSD on XRPL (Ed25519) and Ethereum (secp256k1). Wormhole NTT bridge uses classical signers. Prime brokerage close-out flows depend on classical custody and signing.</div>
+<div class="pilot-verdict">First stablecoin-as-prime-collateral model at scale. If it works, every stablecoin issuer copies it. The architecture they copy should be PQ-native.</div>
+<div class="pilot-alt">EternaX alternative: PQ-native stablecoin issuance with prime-brokerage-grade collateral flow and auditable cross-margin privacy.</div>
+</div>
+
+<div class="pilot-card" id="pilot-cftc">
+<div class="pilot-header"><h3 class="pilot-name" style="margin:0;font-size:0.95rem;">9. CFTC Tokenized Collateral Pilot</span><span class="risk-badge risk-badge-5">Critical</h3></div>
+<div class="pilot-what">CFTC pilot for tokenized collateral in U.S. regulated derivatives markets. Still in consultation phase. Will determine how tokenized MMFs can be posted as margin.</div>
+<div class="pilot-break"><strong>Where it breaks:</strong> The pilot tests collateral using BUIDL, USYC, BENJI on Ethereum, Solana. All classical signatures. Whatever infrastructure the pilot validates becomes the production standard for U.S. regulated derivatives.</div>
+<div class="pilot-verdict">Regulatory pilots are the hardest to change after completion. A CFTC-validated classical-chain collateral framework becomes the benchmark every subsequent proposal is measured against. The regulatory window is closing.</div>
+<div class="pilot-alt">EternaX alternative: PQ-native collateral infrastructure ready for regulatory pilot evaluation. Zero migration debt from inception.</div>
+</div>
+
+<div class="pilot-card" id="pilot-benji">
+<div class="pilot-header"><h3 class="pilot-name" style="margin:0;font-size:0.95rem;">10. Franklin BENJI Nine-Chain Expansion</span><span class="risk-badge risk-badge-4">High</h3></div>
+<div class="pilot-what">Ongoing expansion from Stellar to nine public blockchains. The most aggressive multichain deployment by a regulated U.S. asset manager.</div>
+<div class="pilot-break"><strong>Where it breaks:</strong> Each chain uses Ed25519 or secp256k1. Transfer agent override spans nine networks. Each deployment adds new contracts, admin keys, wallet populations, and legal records referencing chain state. Nine separate migration problems instead of one.</div>
+<div class="pilot-verdict">Franklin is the model other asset managers watch. If the most aggressive tokenized fund manager expands across nine classical chains without PQ consideration, every competitor follows. The industry norm becomes "expand first, migrate later."</div>
+<div class="pilot-alt">EternaX alternative: single PQ-native chain replaces nine classical deployments. One migration surface instead of nine. EVM-compatible.</div>
+</div>
+
+<div class="pull-quote">The $26.7 billion on chain today is not the risk. It is the template. Every pilot that succeeds on classical rails becomes the production default for the ~$300 trillion that follows. The window to influence architecture is during the pilot, not after.</div>
+
+<p class="section-closer">Test the PQ-native version of your pilot on EternaX before the classical version hardens into production.</p>
+</div>
+</section>
+
+<!-- SECTION 6: LEGACY VS NEW ISSUANCE -->
+<div class="section-divider">From Evidence to Action</div>
+<section id="legacy-vs-new">
+<div class="container">
+<h2>6. Legacy Exposure vs New Issuance: The Strategic Fork for Tokenized Finance</h2>
+
+<div class="pull-quote">You cannot rewrite yesterday's issuance. But you choose where tomorrow's assets are born.</div>
+
+<p>Already-issued products require containment: exposure mapping, admin-key hardening, vendor PQ roadmap requirements, and coordinated migration planning. But the $26.7 billion on chain today is a rounding error against the ~$300 trillion that will tokenize over the next decade. Every new stablecoin, tokenized fund, RWA product, collateral pilot, share class, chain expansion, and settlement corridor is a board-level rail-selection decision that determines the infrastructure for that $300 trillion.</p>
+
+<table class="decision-table">
+<thead><tr><th>Situation</th><th>Correct Response</th></tr></thead>
+<tbody>
+<tr><td>Already-issued product on classical rails</td><td>Map exposure, harden admin keys, require PQ roadmaps from vendors, build migration plan.</td></tr>
+<tr><td>Existing product expanding to new chains</td><td>Treat as new issuance. Do not compound migration debt with additional classical chain exposure.</td></tr>
+<tr><td>New stablecoin or tokenized fund in design</td><td>Issue on PQ-native rails. EternaX eliminates migration debt from day one. The cost of choosing correctly now is near zero.</td></tr>
+<tr><td>New collateral pilot</td><td>Test PQ-native collateral flow on EternaX before production default hardens. Pilots become production.</td></tr>
+<tr><td>New bank or private-DLT pilot</td><td>Do not assume permissioned visibility equals PQ-safe privacy. Test PQ-native settlement with auditable privacy.</td></tr>
+<tr><td>New RWA issuance</td><td>Issue PQ-native on EternaX or inherit avoidable cryptographic debt from day one.</td></tr>
+<tr><td>New institutional DeFi integration</td><td>Build on PQ-native authorization and auditable privacy. EternaX is EVM-compatible: existing Solidity deploys directly.</td></tr>
+</tbody>
+</table>
+
+<p>In a crowded tokenization market, the issuer that can say "PQ-native from day one, with auditable privacy and no future migration debt" has a stronger institutional sales story than another classical-chain product waiting for a future retrofit. A PQ-native share class is not only safer. It is a better sales pitch.</p>
+
+<div class="pull-quote">Every new chain deployment is either a distribution expansion or a new migration liability.</div>
+
+<div class="callout callout-green">
+<p class="callout-title">The Board-Level Line</p>
+<p>You cannot rewrite yesterday's issuance. But you choose where tomorrow's assets are born. Every new chain deployment is either a distribution expansion or a new migration liability.</p>
+</div>
+
+<p class="section-closer">A successful pilot on vulnerable rails becomes tomorrow's production liability.</p>
+</div>
+</section>
+
+<!-- SECTION 7: PQ-NATIVE AS DISTRIBUTION ADVANTAGE -->
+<section id="distribution-advantage">
+<div class="container">
+<h2>7. PQ-Native Infrastructure as Distribution Advantage: Why EternaX</h2>
+<p>PQ-native rails create three advantages at once. This is not defensive risk mitigation. It is a competitive weapon.</p>
+
+<div class="advantage-grid">
+<div class="advantage-card">
+<h3>Security Advantage</h3>
+<p>Protects authorization, custody, mint/burn, bridges, settlement, and collateral from future quantum migration risk. Eliminates the admin-key, bridge-signer, and oracle-attestation exposure that dominates the institutional control plane. No migration debt from day one.</p>
+</div>
+<div class="advantage-card">
+<h3>Privacy Advantage</h3>
+<p>Protects institutional flows, treasury movements, counterparties, collateral activity, and sensitive market behavior from store-now-decrypt-later harvesting and public-chain metadata leakage. Auditable privacy: supervisory disclosure without public transparency.</p>
+</div>
+<div class="advantage-card">
+<h3>Distribution Advantage</h3>
+<p>Gives issuers a differentiated reason to win customers, capital, partners, regulators, and institutional trust. "PQ-native from day one" is a new trust category in a market where every issuer competes on yield, liquidity, compliance, brand, and integrations.</p>
+</div>
+</div>
+
+<h3>EternaX: PQ-Native Market Infrastructure</h3>
+<p>EternaX is a PQ-native Layer 1 for stablecoin issuance, RWA tokenization, and institutional settlement. It is the only EVM-compatible chain where post-quantum security, auditable privacy, and DeFi composability are native from genesis.</p>
+
+<p><strong>Conservative where conservatism matters:</strong> SPHINCS+ (NIST SLH-DSA, FIPS 205) as the enterprise standard. Zero algebraic assumptions. <a href="https://eternax.ai/post-quantum-signature-security-ranking-2026.html">45+ years of cryptanalysis, zero successful attacks</a>. The only NIST PQ signature whose security reduces entirely to hash function properties.</p>
+
+<p><strong>Novel where novelty matters:</strong> <a href="https://arxiv.org/abs/2605.03230">SILMARILS</a> (Khodaiemehr, Bagheri, Feng, Porechna; arXiv:2605.03230, UBC and EternaX Labs, May 2026). 160-byte information-theoretic authentication record. 49x smaller than standalone SPHINCS+. Forgery probability ~1/2<sup>255</sup>. Hash-only crypto stack: no pairings, no BLS, no KZG.</p>
+
+<p><strong>Performance:</strong> EternaX loses ~2% throughput under PQ operation (50,000+ TPS to ~49,000+ TPS). Solana loses ~90%. Ethereum models at ~84%. Canton loses ~88%. Finality ~120ms.</p>
+
+<p><strong>EVM compatible:</strong> existing Solidity DeFi protocols deploy with minimal modifications and automatically inherit PQ security and institutional privacy.</p>
+
+<p><strong>Auditable privacy:</strong> validator-blind confidentiality. MEV-zero by architecture. Selective disclosure for supervisory audit. Not privacy-by-policy. Privacy-by-cryptography.</p>
+
+<p>For the full institutional risk framework quantifying $112M-$295M cryptographic migration debt per institution, see the <a href="https://eternax.ai/post-quantum-cryptography-risk-framework-for-institutions.html">EternaX Cryptographic Migration Debt Framework</a>. For the complete post-quantum signature security analysis ranking all NIST PQ families, see the <a href="https://eternax.ai/post-quantum-signature-security-ranking-2026.html">Post-Quantum Signature Security Ranking 2026</a>. For the three-pillar institutional positioning, see <a href="https://eternax.ai/why-eternax.html">Why EternaX: PQ Security, Auditable Privacy, DeFi Composability</a>.</p>
+
+<div class="cta-block">
+<p>The ~$300 trillion tokenization opportunity will choose its rails in the next 3-5 years. The infrastructure that wins will carry institutional value for decades.</p>
+<p>Start with new issuance. Launch the next share class, stablecoin, RWA, collateral pilot, or settlement corridor on PQ-native rails.</p>
+<p>Deploy your existing Solidity contracts on EternaX testnet. Issue a PQ-native stablecoin wrapper. Test collateral movement with auditable privacy. Build evidence before full migration.</p>
+<p style="font-size:0.88rem; opacity:0.85; font-family:'IBM Plex Sans',sans-serif;">Testnet live: 1M+ transactions. 475K+ prediction market bets. 50,000+ TPS. ~120ms finality. Zero migration debt.</p>
+<a href="mailto:paarrthhh.b@eternax.ai" class="cta-link">Book an Institutional Pilot Call</a>
+</div>
+</div>
+</section>
+
+<!-- SECTION 8: FAQ -->
+<section id="faq">
+<div class="container">
+<h2>8. Post-Quantum Risk FAQ: Institutional Crypto, Tokenized Assets, Stablecoins, and RWAs</h2>
+
+<details class="faq-item">
+<summary><h3>What is the post-quantum risk to BlackRock BUIDL?</h3></summary>
+<div class="faq-answer"><p>BUIDL is the single largest PQ dependency cluster in tokenized finance: secp256k1 wallets, concentrated admin keys via Securitize, multichain smart contracts, and downstream reserve dependencies in OUSG and USDtb. A control-plane compromise at the admin level propagates across OKX, Binance, Hidden Road, Komainu, Ondo, and Anchorage. No PQ migration plan disclosed.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is the post-quantum exposure of Circle USYC?</h3></summary>
+<div class="faq-answer"><p>USYC is deployed across five chains (Base, Canton, Ethereum, NEAR, Solana), each using classical signatures. Its two-token model (USYC + USDC redemption) creates interoperability dependencies on Circle attestation services. Deribit accepts it as derivatives collateral. No PQ migration on any chain.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>Is Franklin BENJI post-quantum safe?</h3></summary>
+<div class="faq-answer"><p>No. BENJI touches nine public blockchains using Ed25519 or secp256k1. The transfer agent maintains centralized override, creating concentrated control-plane risk. Each chain deployment compounds migration debt.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is the post-quantum risk to tokenized Treasury funds?</h3></summary>
+<div class="faq-answer"><p>BUIDL ($2.5B), iBENJI ($1.56B), USTB ($988M), JTRSY ($970M), WTGXX ($951M), and BENJI ($825M) all rely on classical signatures for wallet access, admin control, and cross-chain messaging. The Treasury assets are low risk. The rails carrying them are quantum-vulnerable.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>Is Solana post-quantum safe for tokenized assets?</h3></summary>
+<div class="faq-answer"><p>No. Solana uses Ed25519 (Shor-vulnerable). Project Eleven confirmed ~90% TPS loss under PQ migration on a live testnet (April 2026). ~$2.57B in RWA value exposed. No PQ migration roadmap.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is the post-quantum risk to Ethereum institutional tokenization?</h3></summary>
+<div class="faq-answer"><p>5/5 PQ and privacy risk. secp256k1 wallets, BLS consensus, KZG data availability: all quantum-sensitive. Over $5B in tokenized products touch Ethereum. Active PQ research, but multi-year roadmap with no production migration completed.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>Is Canton Network post-quantum secure?</h3></summary>
+<div class="faq-answer"><p>No. Canton's privacy depends on classical encryption, not quantum-durable cryptography. When keys break, all historical flows become retroactively visible. Divulgence documented. ~88% TPS loss under PQ. HNDL attacks already active. Privacy-by-policy is not privacy-by-cryptography.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>Is private DLT post-quantum safe?</h3></summary>
+<div class="faq-answer"><p>No. GS DAP, Kinexys, Canton, and Swift use classical primitives with heavy migration/legal debt. Re-keying must be coordinated across banks, funds, client books, custody, and legal agreements. Permissioned does not mean quantum-safe.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is cryptographic migration debt?</h3></summary>
+<div class="faq-answer"><p>The accumulated cost of transitioning live infrastructure from classical to PQ cryptography: re-keying wallets, rotating admin keys, updating contracts, migrating bridge/oracle signers, re-papering legal agreements. The longer assets stay on classical rails, the higher the debt. See the <a href="https://eternax.ai/post-quantum-cryptography-risk-framework-for-institutions.html">EternaX Migration Debt Framework</a>.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>How does post-quantum risk affect tokenized collateral?</h3></summary>
+<div class="faq-answer"><p>Collateral faces repricing before any key is broken. As the market prices quantum risk, haircuts widen, eligibility narrows, and margin tightens. The commercial consequence precedes the technical event.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is the post-quantum risk to stablecoin reserves?</h3></summary>
+<div class="faq-answer"><p>Stablecoins backed by tokenized MMFs (USDtb/BUIDL, OUSG/BUIDL) create stacked dependencies. Stablecoin admin keys sit on top of reserve-asset admin/oracle/bridge dependence. Breaking the base layer breaks the stablecoin above it.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is auditable privacy for tokenized assets?</h3></summary>
+<div class="faq-answer"><p>Cryptographic protection of institutional flows from public visibility and HNDL harvesting, with selective disclosure to supervisors, auditors, and regulators. Public chains cannot deliver it. Private DLT delivers it through operator trust, not cryptographic guarantees. EternaX delivers it through validator-blind confidentiality by cryptography.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is PQ-native issuance?</h3></summary>
+<div class="faq-answer"><p>Launching new assets on infrastructure where PQ security is native from genesis, not retrofitted. Zero migration debt on day one. EternaX is the only EVM-compatible PQ-native L1, using SPHINCS+ and SILMARILS with ~2% TPS loss.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is PQ-native blockchain infrastructure for institutional use?</h3></summary>
+<div class="faq-answer"><p>A chain where PQ security, auditable privacy, and institutional execution are native from block zero. EternaX: SPHINCS+ (NIST FIPS 205), SILMARILS 160-byte signatures, ~2% TPS loss, validator-blind confidentiality, MEV-zero, EVM compatible. Existing Solidity protocols deploy and automatically inherit PQ security.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is the post-quantum risk to institutional market infrastructure?</h3></summary>
+<div class="faq-answer"><p>DTCC, Swift, Broadridge, and Fnality face the heaviest migration/legal debt. Broadridge processes $362B daily on DLT. The risk is institutional concentration and coordination, not individual wallet compromise.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is the post-quantum risk to J.P. Morgan Kinexys?</h3></summary>
+<div class="faq-answer"><p>Kinexys has processed &gt;$1.5T on a private DLT. The PQ risk is control-plane concentration: bank admin keys, KMS migration, and legal continuity across tokenized deposits and external interoperability. No PQ migration roadmap disclosed.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is the post-quantum risk to Goldman Sachs GS DAP?</h3></summary>
+<div class="faq-answer"><p>Private permissioned ledger mirroring tokenized MMF shares for BNY LiquidityDirect. Exact cryptographic primitives not disclosed. Heaviest migration debt category: re-papering across banks, funds, client books, custody, and legacy systems.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What is the post-quantum risk to WisdomTree tokenized funds?</h3></summary>
+<div class="faq-answer"><p>WTGXX ($951M) operates on Stellar (Ed25519) and Ethereum (secp256k1), both Shor-vulnerable. Migration requires coordination across fund admin, chain infrastructure, and regulatory filings. No PQ plan disclosed.</p></div>
+</details>
+
+<details class="faq-item">
+<summary><h3>What should VCs and institutional allocators evaluate for post-quantum risk in tokenized asset portfolios?</h3></summary>
+<div class="faq-answer"><p>Five dimensions: which chain and primitives carry the asset, who holds admin keys and whether PQ-hardened, bridge/oracle/messaging dependencies, compounding migration debt per chain expansion, and whether new issuance decisions are being made on PQ-native rails. PQ-native positioning is not only risk mitigation; it is a distribution advantage.</p></div>
+</details>
+</div>
+</section>
+
+
+<!-- SECTION 9: AUTHORS AND CONTACT -->
+<section class="team-section" id="authors">
+  <div class="team-inner">
+    <div class="team-label">About the Authors</div>
+    <h2>EternaX Labs | Post-Quantum Financial Infrastructure</h2>
+    <div class="team-grid">
+      <div class="team-card">
+        <div class="team-name">Dariia Porechna</div>
+        <div class="team-role">Co-Founder</div>
+        <div class="team-bio">Cryptographer and distributed systems architect. Former Head of Protocol at Subspace. Former Research Engineer at Wolfram|Alpha. Co-author, SILMARILS.</div>
+        <div class="team-links"><a href="https://www.linkedin.com/in/dariia-porechna" target="_blank" rel="noopener">LinkedIn</a> · <a href="https://x.com/FutureDies" target="_blank" rel="noopener">X</a></div>
+      </div>
+      <div class="team-card">
+        <div class="team-name">Paarrthhh Birla</div>
+        <div class="team-role">Co-Founder</div>
+        <div class="team-bio">Former VP, Growth Office at Polygon. Former Head of Partnerships at Subspace Protocol. Former digital-assets strategy advisor at EYP. MBA, CPA.</div>
+        <div class="team-links"><a href="https://www.linkedin.com/in/paarrthhh-birla-b3607bb4/" target="_blank" rel="noopener">LinkedIn</a> · <a href="https://x.com/parthweb34ai" target="_blank" rel="noopener">X</a></div>
+      </div>
+      <div class="team-card">
+        <div class="team-name">Dr. Chen Feng</div>
+        <div class="team-role">Chief Scientist</div>
+        <div class="team-bio">Associate Professor, University of British Columbia. PhD, University of Toronto. 100+ peer-reviewed papers across quantum communications, blockchain, and TEE privacy. Co-author, SILMARILS.</div>
+        <div class="team-links"><a href="https://www.linkedin.com/in/chen-feng-75272a37" target="_blank" rel="noopener">LinkedIn</a> · <a href="https://scholar.google.com/citations?user=D8b0l-EAAAAJ" target="_blank" rel="noopener">Google Scholar</a></div>
+      </div>
+    </div>
+  </div>
+</section>
+<section class="connect-section">
+  <div class="connect-inner">
+    <div class="connect-label">Contact</div>
+    <h2>Institutional Inquiries</h2>
+    <p class="connect-intro">For institutional inquiries regarding post-quantum financial infrastructure, stablecoin post-quantum architecture, tokenized finance post-quantum risk, privacy-chain post-quantum risk, cryptographic migration debt, pre-upgrade time-at-risk, or EternaX post-quantum infrastructure.</p>
+    <div class="connect-contacts">
+      <div class="connect-person"><span class="name">Paarrthhh Birla</span><span class="connect-sep">-</span><span class="role">Co-Founder</span><span class="connect-sep">-</span><a href="mailto:paarrthhh.b@eternax.ai" class="email">paarrthhh.b@eternax.ai</a></div>
+      <div class="connect-person"><span class="name">Dariia Porechna</span><span class="connect-sep">-</span><span class="role">Co-Founder</span><span class="connect-sep">-</span><a href="mailto:dariia.p@eternax.ai" class="email">dariia.p@eternax.ai</a></div>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER: SCOPE AND METHODOLOGY -->
+<footer class="report-footer">
+<div class="report-footer-inner">
+<p class="section-label">Scope, Methodology, and Limitations</p>
+<p>This report maps 20+ named institutions, 30+ products, and 11 chains/ledgers. It is based on public data, official announcements, regulatory filings, third-party trackers (RWA.xyz, DeFiLlama), and published governance parameters as of May 2026. Asset-specific haircuts on Binance, OKX, Hidden Road/Komainu, and many prime brokers are not publicly disclosed and are not invented. Outstanding collateral balances by venue and exact chain-level allocations for multichain funds are not publicly disclosed. Private-ledger cryptographic primitives are scored on architectural exposure, not a verified cryptographic bill of materials. This report does not constitute investment, legal, or regulatory advice.</p>
+<p><strong>Authors:</strong> Paarrthhh Birla, Dariia Porechna, Dr. Chen Feng &middot; <a href="https://eternax.ai">EternaX Labs</a> &middot; Published May 28, 2026</p>
+<p><strong>Citation:</strong> EternaX Labs, "Post-Quantum Exposure Map 2026: The Institutional Crypto Risk Map for Tokenized Assets, Stablecoins, RWAs, Collateral, Privacy, and New Issuance," May 2026. <a href="https://eternax.ai/post-quantum-exposure-map-institutional-crypto-tokenized-assets-stablecoins-rwa-2026.html">eternax.ai</a></p>
+<p style="margin-top: 1.5rem; font-size: 0.75rem;">&copy; 2026 EternaX Labs. All rights reserved. <a href="https://eternax.ai">eternax.ai</a> &middot; <a href="https://x.com/eternaXLabs">@EternaXlabs</a> &middot; <a href="https://www.linkedin.com/company/eternax-labs">LinkedIn</a> &middot; <a href="https://github.com/eternax-ai">GitHub</a></p>
+</div>
+</footer>
+<footer class="py-12 border-t" style="background-color: var(--bg); border-color: var(--border);" itemscope itemtype="https://schema.org/WPFooter">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex flex-col sm:flex-row items-start justify-between gap-6 mb-6">
+          <div>
+              <span class="text-lg font-bold" style="color: var(--fg)">eternaX</span>
+              <p class="text-sm mt-1" style="color: var(--fg-70)">Quantum-safe Settlement at Market Speed</p>
+              <div class="text-xs" style="color: var(--fg-70)">&copy; 2026 EternaX Labs</div>
+          </div>
+          <div class="flex items-center gap-4">
+              <a href="https://github.com/eternax-ai" class="text-sm link-muted" itemprop="sameAs">GitHub</a>
+              <a href="https://www.youtube.com/@eternaXlabs" class="text-sm link-muted">YouTube</a>
+              <a href="https://t.me/eternax_official" class="text-sm link-muted" itemprop="sameAs">Telegram</a>
+              <a href="https://x.com/EternaXlabs" class="text-sm link-muted" itemprop="sameAs">X (Twitter)</a>
+              <a href="https://www.linkedin.com/company/eternax-labs" class="text-sm link-muted" itemprop="sameAs">LinkedIn</a>
+          </div>
+      </div>
+      <div class="flex items-center gap-4 pt-4 border-t" style="border-color: var(--border);">
+          <a href="about.html" class="text-sm link-muted">About</a>
+          <a href="glossary.html" class="text-sm link-muted">Glossary</a>
+      </div>
+  </div>
+</footer>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const menuButton = document.getElementById('mobile-menu-button');
+  const mobileMenu = document.getElementById('mobile-menu');
+  const iconMenu = document.getElementById('icon-menu');
+  const iconClose = document.getElementById('icon-close');
+
+  function closeMobileMenu() {
+    if (!mobileMenu) return;
+    mobileMenu.classList.add('hidden');
+    if (menuButton) menuButton.setAttribute('aria-expanded', 'false');
+    if (iconMenu) iconMenu.classList.remove('hidden');
+    if (iconClose) iconClose.classList.add('hidden');
+  }
+
+  function openMobileMenu() {
+    if (!mobileMenu) return;
+    mobileMenu.classList.remove('hidden');
+    if (menuButton) menuButton.setAttribute('aria-expanded', 'true');
+    if (iconMenu) iconMenu.classList.add('hidden');
+    if (iconClose) iconClose.classList.remove('hidden');
+  }
+
+  if (menuButton && mobileMenu) {
+    menuButton.addEventListener('click', () => {
+      const isHidden = mobileMenu.classList.contains('hidden');
+      if (isHidden) openMobileMenu();
+      else closeMobileMenu();
+    });
+
+    mobileMenu.querySelectorAll('a').forEach((a) => {
+      a.addEventListener('click', () => closeMobileMenu());
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') closeMobileMenu();
+    });
+
+    window.addEventListener('resize', () => {
+      if (window.innerWidth >= 768) closeMobileMenu();
+    });
+  }
+});
+</script>
+
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -37,6 +37,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://eternax.ai/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html</loc>
+    <lastmod>2026-05-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://eternax.ai/blogs/index.html</loc>
     <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>


### PR DESCRIPTION
## Summary
- Add `post_quantum_exposure_map_institutional_crypto_tokenized_assets.html` and align its structure, typography, navbar/footer behavior, and authors/contact sections with existing institutional report pages.
- Update shared navbar report menus to include the new exposure map at the top and add the new report URL to `sitemap.xml`.
- Clarify risk presentation by replacing ambiguous `PQ X/5` / bare `X/5` labels with explicit severity wording (e.g., `Highly Critical Quantum Risk 5/5`) and move highest-risk card badges below institution names.

## Test plan
- [x] Open `post_quantum_exposure_map_institutional_crypto_tokenized_assets.html` and verify navbar renders and behaves like other report pages (desktop dropdown + mobile toggle).
- [x] Verify report list in navbar includes the new exposure map as first item (desktop and mobile).
- [x] Verify updated risk labels render correctly in institution table, detailed cards, and exposure matrices.
- [x] Verify highest-risk card badges appear below institution names.
- [x] Verify `sitemap.xml` includes the new report URL.