### PR TITLE
Redesign homepage content and institutional layout

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -30,41 +30,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="relative group">
-                    <span class="hover:opacity-70 transition-colors flex items-center gap-1 cursor-default" style="color: var(--fg-70)">Products
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </span>
-                    <div class="nav-products-dropdown absolute left-0 top-full pt-1">
-                        <div class="glass-effect rounded-lg py-2 min-w-[380px] max-w-[420px] shadow-lg" style="border: 1px solid var(--border)">
-                            <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-settlement{% else %}{{ '/index.html#product-settlement' | relative_url }}{% endif %}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Settlement and Execution Layer</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).</span>
-                            </a>
-                            <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-issuance{% else %}{{ '/index.html#product-issuance' | relative_url }}{% endif %}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Stablecoin Issuance</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum RWA Tokenization and Issuance</span>
-                            </a>
-                            <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-migration{% else %}{{ '/index.html#product-migration' | relative_url }}{% endif %}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Migration and Interoperability Rails</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Vault (Ethereum/EVM)</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Migration Bridge</span>
-                            </a>
-                            <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-wallet{% else %}{{ '/index.html#product-wallet' | relative_url }}{% endif %}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b border-transparent hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
-                                <span class="font-semibold text-sm block">Post-Quantum Wallet, Custody, and Policy Controls</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).</span>
-                            </a>
-                            <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-venues{% else %}{{ '/index.html#product-venues' | relative_url }}{% endif %}" class="block px-4 py-3.5 hover:opacity-90 transition-colors hover:bg-black/5 rounded-b-lg" style="color: var(--fg)">
-                                <span class="font-semibold text-sm block">Post-Quantum Market Infrastructure Venues</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">High-velocity trading and information markets powered by PQ-safe collateral and agentic users.</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Perpetuals Exchange (PQ Perps)</span>
-                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)"> - Post-Quantum Prediction Markets</span>
-                            </a>
-                        </div>
-                    </div>
-                </div>
                 <a href="{% if page.url == '/' or page.url == '/index.html' %}#team{% else %}{{ '/index.html#team' | relative_url }}{% endif %}" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
                 <a href="{{ '/blogs/index.html' | relative_url }}" class="hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
                 <a href="mailto:info@eternax.ai" class="btn-primary px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
@@ -93,12 +58,6 @@
                 <a href="{{ '/post-quantum-cryptography-risk-framework-for-institutions.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>
                 <a href="{{ '/already-broken-quantum-risk-report-q1-2026.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Already Broken — Q1 2026</a>
                 <a href="{{ '/blogs/index.html' | relative_url }}" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Blogs</a>
-                <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Products</span>
-                <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-settlement{% else %}{{ '/index.html#product-settlement' | relative_url }}{% endif %}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Settlement and Execution Layer</a>
-                <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-issuance{% else %}{{ '/index.html#product-issuance' | relative_url }}{% endif %}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</a>
-                <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-migration{% else %}{{ '/index.html#product-migration' | relative_url }}{% endif %}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Migration and Interoperability Rails</a>
-                <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-wallet{% else %}{{ '/index.html#product-wallet' | relative_url }}{% endif %}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Wallet, Custody, and Policy Controls</a>
-                <a href="{% if page.url == '/' or page.url == '/index.html' %}#product-venues{% else %}{{ '/index.html#product-venues' | relative_url }}{% endif %}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Market Infrastructure Venues</a>
                 <a href="{% if page.url == '/' or page.url == '/index.html' %}#team{% else %}{{ '/index.html#team' | relative_url }}{% endif %}" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Team</a>
                 <a href="mailto:info@eternax.ai" class="btn-primary block px-4 py-2 rounded-lg text-sm font-semibold text-center text-white">
                     Contact Us

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>EternaX - Post-Quantum Market Infrastructure | PQ-Native Stablecoin Issuance and Settlement</title>
-    <meta name="description" content="EternaX is post-quantum market infrastructure for stablecoin issuance, RWA tokenization, and institutional settlement. PQ-native L1 blockchain with ~160-byte signatures, ~2% TPS overhead, ~120ms finality, and auditable privacy. Built for markets that cannot afford to reprice quantum risk.">
-    <meta name="keywords" content="quantum-safe settlement, post-quantum cryptography, PQ-native assets, market-speed payments, post-quantum market infrastructure, quantum-resistant blockchain, quantum-safe signatures, PQ-safe vaults, post-quantum stablecoin, quantum-safe crypto, quantum threat, quantum-safe DeFi, post-quantum blockchain solutions, quantum-resistant settlement layer">
+    <title>EternaX — PQ-Native Market Infrastructure for Stablecoin Issuance, RWA Tokenization, Tokenized Funds, Collateral, and Institutional Settlement</title>
+    <meta name="description" content="EternaX is PQ-native, EVM-compatible market infrastructure for stablecoin issuance, RWA tokenization, tokenized funds, collateral movement, and institutional settlement. SLH-DSA (SPHINCS+), SILMARILS 160-byte authentication, auditable privacy, 50,000-200,000 TPS target, and ~2% PQ overhead.">
+    <meta name="keywords" content="post-quantum blockchain, PQ-native blockchain, PQ-native stablecoin issuance, post-quantum stablecoin, RWA tokenization, tokenized funds, institutional settlement layer, quantum-safe settlement, auditable privacy, cryptographic migration debt, EVM compatible post-quantum blockchain, institutional blockchain privacy, post-quantum market infrastructure, collateral settlement, SILMARILS, SLH-DSA, SPHINCS+, EternaX">
     <meta name="author" content="eternaX Labs">
     <meta name="publisher" content="eternaX Labs">
     <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
@@ -31,8 +31,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://eternax.ai/">
-    <meta property="og:title" content="EternaX - Post-Quantum Market Infrastructure">
-    <meta property="og:description" content="Post-quantum native L1 for stablecoin issuance, RWA tokenization, and institutional settlement. 160-byte PQ signatures. ~2% TPS overhead. ~120ms finality. The only architecture where cryptographic migration debt does not arise.">
+    <meta property="og:title" content="EternaX — Do Not Issue Tomorrow's Institutional Assets on Yesterday's Cryptography">
+    <meta property="og:description" content="PQ-native market infrastructure combining quantum-durable privacy, EVM composability, and post-quantum security for stablecoins, RWAs, tokenized funds, collateral, and institutional settlement.">
     <meta property="og:image" content="https://eternax.ai/assets/preview.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -43,8 +43,8 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://eternax.ai/">
-    <meta property="twitter:title" content="EternaX - Post-Quantum Market Infrastructure">
-    <meta property="twitter:description" content="Post-quantum native L1 for stablecoin issuance, RWA tokenization, and institutional settlement. 160-byte PQ signatures. ~2% TPS overhead. ~120ms finality. The only architecture where cryptographic migration debt does not arise.">
+    <meta property="twitter:title" content="EternaX — Do Not Issue Tomorrow's Institutional Assets on Yesterday's Cryptography">
+    <meta property="twitter:description" content="PQ-native market infrastructure for stablecoin issuance, RWA tokenization, tokenized funds, collateral, and institutional settlement.">
     <meta property="twitter:image" content="https://eternax.ai/assets/preview.png">
     <meta property="twitter:image:alt" content="EternaX - Post-Quantum Market Infrastructure">
     <meta property="twitter:site" content="@EternaXlabs">
@@ -58,8 +58,8 @@
     <link rel="dns-prefetch" href="//fonts.googleapis.com">
     <link rel="dns-prefetch" href="//fonts.gstatic.com">
     <link rel="stylesheet" href="./styles/tailwind.generated.css">
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Condensed:wght@300;400;500;600;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Condensed:wght@300;400;500;600;700&display=swap" rel="stylesheet"></noscript>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Condensed:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Condensed:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"></noscript>
     
     <!-- Structured Data for AI Engines -->
     <script type="application/ld+json">
@@ -189,6 +189,7 @@
         ]
     }
     </script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What problem does EternaX solve for institutions?","acceptedAnswer":{"@type":"Answer","text":"EternaX solves the new-issuance problem for institutional digital assets. Stablecoins, RWAs, tokenized funds, collateral systems, and settlement workflows launched on classical blockchain rails inherit future post-quantum migration debt. EternaX lets institutions issue and settle assets on PQ-native rails from day one, with auditable privacy, EVM compatibility, and market-speed finality."}},{"@type":"Question","name":"What is EternaX?","acceptedAnswer":{"@type":"Answer","text":"EternaX is a PQ-native, EVM-compatible Layer 1 blockchain for institutional settlement, stablecoin issuance, RWA tokenization, tokenized funds, collateral movement, and migration from classical chains. It combines SLH-DSA/SPHINCS+ as the conservative post-quantum security anchor, SILMARILS for compact transaction authentication, auditable privacy for institutional flows, and market-speed settlement for production financial infrastructure."}},{"@type":"Question","name":"Who should evaluate EternaX before issuing digital assets?","acceptedAnswer":{"@type":"Answer","text":"Stablecoin issuers, RWA platforms, tokenized fund managers, banks, custodians, exchanges, prime brokers, collateral venues, payment networks, asset managers, and digital-asset infrastructure teams should evaluate EternaX before launching a new product or expanding an existing product to another classical chain."}},{"@type":"Question","name":"What can an institution pilot first on EternaX?","acceptedAnswer":{"@type":"Answer","text":"The cleanest first pilot is a PQ-native issuance or settlement workflow: a stablecoin wrapper, tokenized fund share class, RWA test issuance, collateral movement flow, custody-policy flow, private settlement corridor, or Solidity-based DeFi contract deployed on EternaX testnet. The goal is to prove post-quantum authorization, auditable privacy, and settlement performance before a production rail decision hardens."}},{"@type":"Question","name":"Is EternaX for new issuance, legacy migration, or both?","acceptedAnswer":{"@type":"Answer","text":"Both, but the highest-value starting point is new issuance. Legacy assets require exposure mapping, admin-key hardening, vendor PQ roadmap review, and coordinated migration planning. New issuance is cleaner: institutions can avoid creating fresh cryptographic migration debt by issuing stablecoins, RWAs, funds, and collateral instruments on PQ-native rails from day one."}},{"@type":"Question","name":"Does EternaX require abandoning Ethereum, Solana, Canton, or existing infrastructure?","acceptedAnswer":{"@type":"Answer","text":"No. EternaX can complement existing infrastructure. Institutions can keep legacy assets where they are, deploy EVM-compatible contracts on EternaX, test PQ-native issuance, build migration rails, and route selected settlement, collateral, or custody workflows through post-quantum infrastructure without immediately abandoning existing systems."}},{"@type":"Question","name":"Is EternaX EVM compatible?","acceptedAnswer":{"@type":"Answer","text":"Yes. EternaX is EVM-compatible, so existing Solidity contracts, token contracts, DeFi protocols, custody-policy logic, collateral workflows, and settlement applications can deploy with minimal modifications. Institutions do not need to rebuild an entirely new developer stack to test PQ-native issuance or settlement."}},{"@type":"Question","name":"What is EternaX's throughput and settlement speed?","acceptedAnswer":{"@type":"Answer","text":"EternaX targets 50,000-200,000 TPS, approximately 2% PQ throughput overhead, 20-50ms soft finality, and 400-520ms hard-finality settlement for institutional market-infrastructure workloads. The point is not raw TPS marketing; it is post-quantum security without collapsing settlement capacity, collateral movement, redemptions, or EVM-compatible execution."}},{"@type":"Question","name":"What makes EternaX a post-quantum-native blockchain?","acceptedAnswer":{"@type":"Answer","text":"EternaX is post-quantum-native because its core authorization path contains zero classical signature primitives such as ECDSA, Ed25519, BLS, or KZG. It uses SLH-DSA/SPHINCS+ as the conservative post-quantum security anchor and SILMARILS for compact transaction authentication, enabling PQ-native operation without the large throughput collapse associated with retrofit paths."}},{"@type":"Question","name":"Why does EternaX use SLH-DSA/SPHINCS+ instead of Dilithium, Falcon, or other lattice-based schemes?","acceptedAnswer":{"@type":"Answer","text":"SLH-DSA/SPHINCS+ is the only NIST-standardized post-quantum signature scheme whose security relies entirely on hash functions — a mathematical primitive studied since 1979 with zero successful attacks. Dilithium (ML-DSA) and Falcon rely on lattice-based algebraic assumptions (Module-LWE and NTRU) that are decades younger and face active cryptanalytic research. For an institution issuing stablecoins, tokenized funds, or settlement rails expected to survive 20-30 years of cryptographic scrutiny, this distinction is not academic — it is a fiduciary question. If lattice assumptions weaken or break, every asset authorized by Dilithium or Falcon requires emergency re-keying and migration — a second cryptographic migration crisis layered on top of the classical-to-PQ migration institutions already face. SLH-DSA/SPHINCS+ eliminates that tail risk entirely. Falcon carries additional implementation risk: it requires complex floating-point arithmetic during signing, creating a wider side-channel attack surface that NIST itself flagged as a concern. The trade-off institutions face elsewhere is that SLH-DSA/SPHINCS+ produces large signatures (~7,800 bytes) that collapse throughput. EternaX resolves this with SILMARILS, which compresses PQ authentication to 160 bytes — a 49x reduction — while preserving SLH-DSA/SPHINCS+-level security. The result: institutions get the most conservative NIST standard at 50,000-200,000 TPS with ~2% throughput loss, not the 84-90% collapse every other chain faces."}},{"@type":"Question","name":"What is the post-quantum signature size problem and why does it threaten institutional blockchain throughput?","acceptedAnswer":{"@type":"Answer","text":"Classical signature schemes used by every major blockchain today — Ed25519 on Solana and Stellar, secp256k1 on Ethereum and Bitcoin — produce signatures of 64-72 bytes. Post-quantum signature schemes produce dramatically larger signatures: SLH-DSA/SPHINCS+ at ~7,800 bytes (over 100x larger), Dilithium (ML-DSA) at 2,420-4,627 bytes (38-72x larger), and Falcon at 666 bytes (10x larger). Blockchain throughput is bandwidth-constrained. Every transaction carries a signature. When signature size increases by 10-100x, fewer transactions fit per block, and throughput collapses proportionally. This is not theoretical: Project Eleven and the Solana Foundation observed ~90% TPS loss on a live Solana testnet using PQ signatures in April 2026. EternaX models ~84% loss for Ethereum, ~88% for Canton, and ~90% for Stellar under similar PQ retrofit assumptions. This is the core reason post-quantum migration is not just a security upgrade — it is a throughput crisis. Institutions that wait for their current chain to add PQ support face a choice: accept a weaker-but-smaller scheme like Dilithium or Falcon (taking on algebraic risk), or adopt the conservative standard SLH-DSA/SPHINCS+ and accept throughput collapse. EternaX is the only infrastructure that resolves this trade-off. SILMARILS compresses SLH-DSA/SPHINCS+-grade security to 160 bytes, delivering ~2% throughput loss instead of 84-90%."}},{"@type":"Question","name":"What risks do institutions face if they choose Dilithium or Falcon instead of SLH-DSA/SPHINCS+ for post-quantum security?","acceptedAnswer":{"@type":"Answer","text":"Three categories of risk. First, cryptographic survivability risk. Dilithium and Falcon rely on structured lattice assumptions (Module-LWE and NTRU) that have been studied for approximately 25 years. SLH-DSA/SPHINCS+ relies on hash-function security studied since 1979. Lattice cryptanalysis is an active research frontier — advances in lattice reduction, algebraic attacks, or quantum lattice algorithms could weaken these schemes partially or fully. If that happens, every asset, key, and authorization built on Dilithium or Falcon requires emergency re-keying and migration. That is a second migration crisis on top of the classical-to-PQ migration institutions already face. SLH-DSA/SPHINCS+ does not carry this tail risk because its security reduces to hash-function collision resistance, the most conservative and well-understood assumption in post-quantum cryptography. Second, throughput risk. Even the smaller lattice-based signatures — Dilithium at 2,420 bytes, Falcon at 666 bytes — are still 10-38x larger than classical signatures. Chains retrofitting with these schemes still face material throughput degradation. Institutions choosing Dilithium or Falcon accept weaker security and still do not get classical-speed settlement. Third, fiduciary and regulatory risk. As PQ migration timelines harden (NIST IR 8547, NSA CNSA 2.0, CISA federal mandates), institutions that chose a less conservative PQ scheme when a commercially viable conservative alternative existed may face questions about prudent risk management. The existence of EternaX — SLH-DSA/SPHINCS+ at 50,000-200,000 TPS with ~2% overhead — changes the calculus. Choosing Dilithium or Falcon is defensible only if SLH-DSA/SPHINCS+ at market speed is unavailable. On EternaX, it is available."}},{"@type":"Question","name":"What is SILMARILS and why does it matter for post-quantum throughput?","acceptedAnswer":{"@type":"Answer","text":"SILMARILS is EternaX's compact transaction-authentication layer, co-developed with UBC and EternaX Labs. It is designed to reduce the transaction authentication footprint to 160 bytes while preserving strong verification and auditability properties. This matters because standard post-quantum signatures can create major signature-size and throughput penalties when retrofitted onto high-performance chains."}},{"@type":"Question","name":"What is auditable privacy for stablecoins, RWAs, and institutional settlement?","acceptedAnswer":{"@type":"Answer","text":"Auditable privacy means institutional transaction details are not publicly exposed by default, while authorized parties can receive selective disclosure for supervision, audit, compliance, and counterparty verification. The goal is privacy by cryptography, not privacy by policy or simple access control. For stablecoins, RWAs, tokenized funds, and collateral flows, this protects treasury movements, counterparties, balances, and order flow while preserving compliance visibility."}},{"@type":"Question","name":"Is blockchain privacy post-quantum safe? What about Canton, Zcash, Monero, and other privacy chains?","acceptedAnswer":{"@type":"Answer","text":"No. The privacy of every major private or privacy-focused blockchain today depends on classical elliptic-curve or pairing-based cryptography that a quantum computer can break. Canton Network uses classical enterprise cryptography, Zcash relies on elliptic-curve shielded-pool primitives, Monero uses Ed25519 and Curve25519, and many ZK systems rely on pairing-based or elliptic-curve assumptions. Harvest-now-decrypt-later collection means data recorded today can become vulnerable later. EternaX is designed for quantum-durable privacy based on post-quantum-safe primitives rather than classical privacy assumptions."}},{"@type":"Question","name":"What is cryptographic migration debt in tokenized assets and stablecoins?","acceptedAnswer":{"@type":"Answer","text":"Cryptographic migration debt is the future cost of moving assets, contracts, admin keys, custody systems, compliance workflows, legal records, liquidity, and settlement processes from classical cryptography to post-quantum cryptography. Every stablecoin, tokenized fund, RWA product, collateral system, or settlement corridor launched on classical rails creates debt that must later be mapped, coordinated, legally re-certified, and migrated."}},{"@type":"Question","name":"How does EternaX compare to Ethereum, Solana, and Canton for institutional tokenization?","acceptedAnswer":{"@type":"Answer","text":"EternaX is designed to combine PQ-native security, auditable privacy, EVM compatibility, and market-speed settlement from genesis. Ethereum has the deepest EVM ecosystem but is not PQ-native today; EternaX's methodology models approximately 84% TPS loss under large-signature PQ retrofit assumptions. Solana uses Ed25519 today, and Project Eleven / Solana Foundation testing observed approximately 90% TPS loss under PQ migration. Canton has strong institutional privacy positioning, but its privacy depends on classical cryptographic infrastructure; if classical privacy keys are broken, historical confidentiality can be retroactively exposed, and EternaX's methodology models approximately 88% TPS loss for Canton-style large-PQ-signature paths. Stellar uses Ed25519, has no public PQ roadmap, and EternaX's methodology models approximately 90% TPS loss under a large-signature PQ retrofit path."}},{"@type":"Question","name":"Which blockchain should institutions use for new stablecoin, RWA, or tokenized fund issuance in 2026?","acceptedAnswer":{"@type":"Answer","text":"For new stablecoin, RWA, or tokenized fund issuance in 2026, institutions should evaluate EternaX as the PQ-native, EVM-compatible rail built specifically to avoid classical-to-post-quantum migration debt. The right chain should be PQ-native from day one, support auditable privacy, preserve DeFi composability, integrate with custody and compliance workflows, and avoid forcing a future cryptographic migration."}},{"@type":"Question","name":"Is PQ-native issuance a distribution and sales advantage, not just a security advantage?","acceptedAnswer":{"@type":"Answer","text":"Yes. In a crowded tokenization market where every issuer competes on yield, liquidity, compliance, brand, and trust, post-quantum-native issuance creates a new trust category. A stablecoin issuer on PQ-native rails can tell institutional clients its product is post-quantum-native from day one with quantum-durable privacy and zero migration debt. No issuer on Ethereum, Solana, Canton, or Stellar can make that claim today. The first issuers to claim PQ-native positioning set the standard. PQ-native is not only safer infrastructure, it is a stronger institutional sales story."}},{"@type":"Question","name":"Why is post-quantum migration urgent for institutional crypto in 2026?","acceptedAnswer":{"@type":"Answer","text":"Post-quantum migration is urgent in 2026 because institutions are making rail-selection decisions now that may define the infrastructure for the next $300 trillion in tokenized assets. Four forcing functions matter: Google Quantum AI compressed the qubit threshold to fewer than 500,000 physical qubits in March 2026; Solana PQ testing observed approximately 90% TPS loss in April 2026; NSA CNSA 2.0 requires quantum-safe new national-security systems by January 2027; and NIST has proposed deprecating ECDSA and EdDSA by 2030. New issuance on classical rails creates migration debt before the attack arrives."}},{"@type":"Question","name":"Is EternaX a stablecoin issuer or infrastructure for issuers?","acceptedAnswer":{"@type":"Answer","text":"EternaX is infrastructure for issuers, not a competing stablecoin issuer. Stablecoin teams, banks, payment networks, asset managers, and RWA platforms can use EternaX to issue, settle, custody, and migrate assets on PQ-native rails with auditable privacy and EVM-compatible execution."}},{"@type":"Question","name":"How does EternaX support compliance, custody, KYC/AML, and auditors?","acceptedAnswer":{"@type":"Answer","text":"EternaX is designed for compliance-native workflows: selective disclosure for auditors and supervisors, confidential transaction details by default, custody-policy integration, KYC/AML-compatible governance, and auditable settlement evidence. The aim is not public transparency or opaque privacy. The aim is institutional confidentiality with controlled verification."}},{"@type":"Question","name":"What should an institution review before booking an EternaX pilot?","acceptedAnswer":{"@type":"Answer","text":"Institutions should review the Post-Quantum Exposure Map, the Cryptographic Migration Debt Framework, the Post-Quantum Signature Security Ranking, the SILMARILS paper, and the live EternaX testnet. Together, these materials explain the institutional exposure, the migration-debt thesis, the cryptographic design, and the first pilot path for PQ-native issuance or settlement."}},{"@type":"Question","name":"Who founded EternaX?","acceptedAnswer":{"@type":"Answer","text":"EternaX was founded by Paarrthhh Birla, Dariia Porechna, and Dr. Chen Feng. Paarrthhh Birla previously worked in the Polygon Growth Office, led partnerships at Subspace Protocol, and advised digital-asset strategy work connected to Visa and State Street. Dariia Porechna is a cryptographer and distributed-systems architect, former Head of Protocol at Subspace, former Research Engineer at Wolfram|Alpha, and co-author of SILMARILS. Dr. Chen Feng is an Associate Professor at the University of British Columbia, Principal's Research Chair, Blockchain@UBC co-lead, PhD from the University of Toronto, author of 100+ peer-reviewed papers, and co-author of SILMARILS."}}]}</script>
     <style>
         :root {
             --bg: #f7f4f4;
@@ -243,11 +244,189 @@
         .hero-network-bg {
             background-image: url("./assets/eternax-network.webp");
             background-position: center bottom;
+            transform: scaleX(-1);
         }
         @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
             .hero-network-bg {
                 background-image: url("./assets/eternax-network.svg");
             }
+        }
+
+        .hero-signals {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px 20px;
+            margin-bottom: 2.75rem;
+        }
+        .hero-signals span {
+            font-size: 0.75rem;
+            font-weight: 500;
+            color: rgba(40, 55, 113, 0.72);
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .hero-signals span::before {
+            content: '';
+            width: 4px;
+            height: 4px;
+            border-radius: 50%;
+            background: #2F5E52;
+            flex-shrink: 0;
+        }
+
+        .hero-metrics {
+            display: grid;
+            grid-template-columns: repeat(5, minmax(0, 1fr));
+        }
+        .hero-metrics--4 {
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+        }
+        .hero-metrics-item {
+            padding: 1.75rem 0.75rem;
+            text-align: center;
+            border-right: 1px solid #e0dede;
+        }
+        .hero-metrics-item:last-child {
+            border-right: none;
+        }
+        .hero-metrics-value {
+            font-family: "IBM Plex Mono", ui-monospace, monospace;
+            font-size: 1.375rem;
+            font-weight: 700;
+            color: var(--fg);
+            margin-bottom: 5px;
+        }
+        .hero-metrics-value.accent {
+            color: #2F5E52;
+        }
+        .hero-metrics-label {
+            font-size: 0.6875rem;
+            color: rgba(40, 55, 113, 0.72);
+            line-height: 1.45;
+        }
+
+        .why-now-strip {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+        }
+        .why-now-item {
+            padding: 0 1.5rem;
+            border-right: 1px solid #e0dede;
+        }
+        .why-now-item:first-child {
+            padding-left: 0;
+        }
+        .why-now-item:last-child {
+            border-right: none;
+            padding-right: 0;
+        }
+        .why-now-date {
+            font-family: "IBM Plex Mono", ui-monospace, monospace;
+            font-size: 0.75rem;
+            font-weight: 600;
+            color: var(--fg);
+            margin-bottom: 6px;
+        }
+        .why-now-text {
+            font-size: 0.8125rem;
+            color: rgba(40, 55, 113, 0.72);
+            line-height: 1.55;
+        }
+
+        .stat-break-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 3rem;
+            align-items: start;
+        }
+        @media (max-width: 767px) {
+            .stat-break-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .use-cases-strip {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+        }
+        .use-cases-item {
+            padding: 0 1.25rem;
+            border-right: 1px solid #e0dede;
+        }
+        .use-cases-item:first-child {
+            padding-left: 0;
+        }
+        .use-cases-item:last-child {
+            border-right: none;
+            padding-right: 0;
+        }
+
+        .evidence-reports {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+            gap: 12px;
+        }
+
+        .cta-steps {
+            list-style: none;
+            padding: 0;
+            margin: 0 0 1.5rem;
+        }
+        .cta-steps li {
+            display: flex;
+            gap: 0.875rem;
+            align-items: flex-start;
+            padding: 0.625rem 0;
+            font-size: 0.875rem;
+            line-height: 1.5;
+            color: rgba(40, 55, 113, 0.72);
+            border-bottom: 1px solid #e0dede;
+        }
+        .cta-steps li:last-child {
+            border-bottom: none;
+        }
+        .cta-steps li .num {
+            flex-shrink: 0;
+            min-width: 1.25rem;
+            font-family: "IBM Plex Mono", ui-monospace, monospace;
+            font-size: 0.625rem;
+            font-weight: 700;
+            color: #2F5E52;
+            line-height: 1.5;
+            padding-top: 0.125rem;
+        }
+
+        .cta-card {
+            padding: 2.75rem 2.25rem;
+        }
+        .cta-links {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.875rem;
+            align-items: center;
+        }
+        .btn-cta {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.75rem 1.5rem;
+            border-radius: 0.5rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            line-height: 1.25;
+            text-align: center;
+        }
+        .btn-cta-secondary {
+            padding: 0.75rem 1.375rem;
+            border: 1px solid #e0dede;
+            color: var(--fg);
+            background: #ffffff;
+            transition: border-color 0.15s, background-color 0.15s;
+        }
+        .btn-cta-secondary:hover {
+            border-color: #2F5E52;
+            background: rgba(47, 94, 82, 0.04);
         }
     </style>
 </head>
@@ -258,605 +437,610 @@
     <!-- Hero Section -->
     <section class="flex items-center justify-center relative overflow-hidden pt-32 lg:pt-40 pb-12 lg:pb-16" itemscope itemtype="https://schema.org/WebPageElement" itemprop="mainContentOfPage">
         <div class="hero-network-bg absolute inset-0 bg-center bg-no-repeat opacity-80"></div>
-        <div class="relative z-10 w-full max-w-7xl mx-auto px-4 flex flex-col lg:flex-row gap-8 items-center lg:items-start">
-            <!-- Left side: 2/3 width -->
-            <div class="w-full lg:w-2/3 flex flex-col">
-                <h1 class="w-full text-left font-semibold tracking-tight mb-6 py-8 font-condensed" itemprop="headline" style="font-size: clamp(2.5rem, 6vw, 5rem); line-height: 1.1; color: var(--fg);">
-                    Quantum-safe<br>Settlement at <br>Market speed
-                </h1>
-                <p class="text-xl md:text-2xl mb-8 text-left" itemprop="description" style="color:  var(--fg)">
-                    PQ-native assets. Market-speed payments and settlement.
-                </p>
-                <p class="text-xl md:text-2xl mb-8 font-semibold text-left" style="color: var(--fg)">
-                    Post-quantum market infrastructure built to stay fast when markets reprice quantum risk.
-                </p>
-            </div>
-            
-            <!-- Right side: 1/3 width - Spec strip -->
-            <div class="w-full lg:w-1/3 flex flex-col gap-4">
-                <div class="glass-effect p-4 rounded-lg">
-                    <div class="font-semibold mb-2" style="color: var(--fg)">Post-Quantum core</div>
-                    <div class="text-sm" style="color: var(--fg-80)">Protocol-native PQ authorization with <a href="blogs/silmarils-post-quantum-authentication-without-size-tax/index.html" style="color:inherit;">novel 160B signatures</a></div>
-                </div>
-                <div class="glass-effect p-4 rounded-lg">
-                    <div class="font-semibold mb-2" style="color: var(--fg)">Privacy</div>
-                    <div class="text-sm" style="color: var(--fg-80)">Auditable privacy. Hidden balances, hidden transaction details, hidden intent, selective disclosure</div>
-                </div>
-                <div class="glass-effect p-4 rounded-lg">
-                    <div class="font-semibold mb-2" style="color: var(--fg)">Finality</div>
-                    <div class="text-sm" style="color: var(--fg-80)">~120ms spendable finality target</div>
-                </div>
-                <div class="glass-effect p-4 rounded-lg">
-                    <div class="font-semibold mb-2" style="color: var(--fg)">Low Fees</div>
-                    <div class="text-sm" style="color: var(--fg-80)">Deterministic capped fees for payments and settlement (< $0.001 target)</div>
-                </div>
-            </div>
-        </div>
-
-    </section>
-
-    <!-- Proof Section -->
-    <section class="pt-12 pb-20" style="background-color: var(--bg); border-color: var(--border);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 class="text-4xl sm:text-5xl font-semibold tracking-tight mb-8" style="color: var(--fg)">
-                Infrastructure Moat
-            </h2>
-            <div class="max-w-4xl mb-12">
-                <p class="text-lg mb-4" style="color: var(--fg-80)">
-                    If PQ signatures are large, the cost shows up forever in throughput plus coordination.
-                </p>
-                <p class="text-lg" style="color: var(--fg-80)">
-                    Stablecoins already move on a multi-10-trillion annual rail. Issuance locks authorization for years. Signature bytes are the throughput bill. If PQ is expensive, liquidity routes around it.
-                </p>
-            </div>
-
-            <div class="mb-12">
-                
-                <!-- Three Data Cards -->
-                <div class="grid md:grid-cols-3 gap-6 mb-12">
-                <div class="glass-effect p-6 rounded-lg">
-                        <div class="flex justify-between items-start mb-3">
-                            <div class="font-semibold text-lg" style="color: var(--fg)">EternaX (novel)</div>
-                        </div>
-                        <div class="text-4xl font-bold mb-2" style="color: var(--fg);">160B</div>
-                        <div class="text-sm mb-2" style="color: var(--fg-80)">Baseline</div>
-                        <div class="text-sm" style="color: var(--fg-80)">Low-single-digit overhead</div>
-                </div>
-                
-                <div class="glass-effect p-6 rounded-lg">
-                        <div class="font-semibold text-lg mb-3" style="color: var(--fg)">Falcon-class</div>
-                        <div class="text-4xl font-bold mb-2" style="color: var(--fg);">666B</div>
-                        <div class="text-sm mb-2" style="color: var(--fg-80)">vs EternaX: ~4.2×</div>
-                        <div class="text-sm" style="color: var(--fg-80)">Material overhead risk</div>
-                </div>
-                
-                <div class="glass-effect p-6 rounded-lg">
-                        <div class="font-semibold text-lg mb-3" style="color: var(--fg)">Dilithium-class+</div>
-                        <div class="text-4xl font-bold mb-2" style="color: var(--fg);">2,420B+</div>
-                        <div class="text-sm mb-2" style="color: var(--fg-80)">vs EternaX: 15×+</div>
-                        <div class="text-sm" style="color: var(--fg-80)">High overhead risk</div>
-                </div>
-            </div>
-            
-                <!-- Bar Chart Section -->
-                <div class="glass-effect p-6 rounded-lg">
-                    <div class="flex justify-between items-start mb-4">
-                        <div>
-                            <h3 class="text-xl font-semibold mb-2" style="color: var(--fg)">
-                                Modeled TPS throughput loss caused by PQ authorization
-                            </h3>
-                            <p class="text-sm mb-4" style="color: var(--fg-80)">
-                                Transaction throughput loss under fixed budgets. Falcon-class assumption for incumbents: ~666B signatures (about 4.2× EternaX).
-                </p>
-            </div>
-        </div>
-                    
-                    <!-- Bar Chart -->
-                    <div class="space-y-6">
-                        <!-- Solana -->
-                        <div>
-                            <div class="flex items-center justify-between mb-2">
-                                <div class="flex items-center gap-4">
-                                    <span class="font-semibold" style="color: var(--fg)">Solana</span>
-                                    <span class="text-sm" style="color: var(--fg-80)">666B 4.2×</span>
-                                </div>
-                                <span class="text-sm font-semibold" style="color: var(--fg)">-77%</span>
-                            </div>
-                            <div class="relative h-8 rounded-sm overflow-hidden" style="background-color: rgba(0,0,0,0.05);">
-                                <div class="h-full rounded-sm flex items-center justify-end pr-4" style="background-color: var(--fg); width: 77%;">
-                                    <span class="text-xs text-white font-semibold">-77%</span>
-                                </div>
-                            </div>
-                        </div>
-                        
-                        <!-- Sui -->
-                        <div>
-                            <div class="flex items-center justify-between mb-2">
-                                <div class="flex items-center gap-4">
-                                    <span class="font-semibold" style="color: var(--fg)">Sui</span>
-                                    <span class="text-sm" style="color: var(--fg-80)">666B 4.2×</span>
-                                </div>
-                                <span class="text-sm font-semibold" style="color: var(--fg)">-69%</span>
-                            </div>
-                            <div class="relative h-8 rounded-sm overflow-hidden" style="background-color: rgba(0,0,0,0.05);">
-                                <div class="h-full rounded-sm flex items-center justify-end pr-4" style="background-color: var(--fg); width: 69%;">
-                                    <span class="text-xs text-white font-semibold">-69%</span>
-                                </div>
-                            </div>
-                        </div>
-                        
-                        <!-- Ethereum -->
-                        <div>
-                            <div class="flex items-center justify-between mb-2">
-                                <div class="flex items-center gap-4">
-                                    <span class="font-semibold" style="color: var(--fg)">Ethereum</span>
-                                    <span class="text-sm" style="color: var(--fg-80)">666B 4.2×</span>
-                                </div>
-                                <span class="text-sm font-semibold" style="color: var(--fg)">-31%</span>
-                            </div>
-                            <div class="relative h-8 rounded-sm overflow-hidden" style="background-color: rgba(0,0,0,0.05);">
-                                <div class="h-full rounded-sm flex items-center justify-end pr-4" style="background-color: var(--fg); width: 31%;">
-                                    <span class="text-xs text-white font-semibold">-31%</span>
-                                </div>
-                            </div>
-                        </div>
-                        
-                        <!-- EternaX -->
-                        <div>
-                            <div class="flex items-center justify-between mb-2">
-                                <div class="flex items-center gap-4">
-                                    <span class="font-semibold" style="color: var(--fg)">EternaX</span>
-                                    <span class="text-sm" style="color: var(--fg-80)">160B 1×</span>
-                                </div>
-                                <span class="text-sm font-semibold" style="color: var(--fg)">-2%</span>
-                            </div>
-                            <div class="relative h-8 rounded-sm overflow-hidden" style="background-color: rgba(0,0,0,0.05);">
-                                <div class="h-full rounded-sm flex items-center justify-end pr-4" style="background-color: var(--fg); width: 2%;">
-                                    <span class="text-xs text-white font-semibold">-2%</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- X-axis labels -->
-                    <div class="flex justify-between mt-4 pt-4 border-t" style="border-color: var(--border);">
-                        <span class="text-xs" style="color: var(--fg-80)">-80%</span>
-                        <span class="text-xs" style="color: var(--fg-80)">-60%</span>
-                        <span class="text-xs" style="color: var(--fg-80)">-40%</span>
-                        <span class="text-xs" style="color: var(--fg-80)">-20%</span>
-                        <span class="text-xs" style="color: var(--fg-80)">0%</span>
-                    </div>
-                    
-                    <!-- Footnote -->
-                    <p class="text-xs mt-6 pt-4 border-t" style="color: var(--fg-80); border-color: var(--border);">
-                        <a href="blogs/silmarils-post-quantum-authentication-without-size-tax/index.html" style="color:inherit;">EternaX signature</a> size and scheme are detailed on arXiv. Byte values depend on parameterization and encoding. TPS loss figures are computed under stated assumptions, not exact production TPS.
-                    </p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Products Section -->
-    <section id="products" class="pt-12 pb-20" style="background-color: var(--bg); border-color: var(--border);">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 class="text-4xl sm:text-5xl font-semibold tracking-tight mb-4" style="color: var(--fg)">
-                Products
-            </h2>
-            <p class="text-2xl font-semibold mb-12" style="color: var(--fg)">
-                Preserve → Migrate → Settle → Trade → Pay
+        <div class="relative z-10 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <p class="text-sm font-semibold uppercase tracking-widest mb-6" style="color: #2F5E52;">Post-Quantum-Native Market Infrastructure</p>
+            <h1 class="w-full text-left font-semibold tracking-tight mb-6 font-condensed" itemprop="headline" style="font-size: clamp(2.5rem, 6vw, 4.5rem); line-height: 1.08; color: var(--fg);">
+                Quantum-safe, Private Settlement<br>at Market Speed
+            </h1>
+            <p class="text-xl md:text-2xl mb-6 font-semibold text-left max-w-3xl" style="color: var(--fg);">
+                Do not issue tomorrow's institutional assets on yesterday's cryptography.
             </p>
-            <p class="text-xl mb-12" style="color: var(--fg-80)">
-                EternaX upgrades asset security and settlement without imposing a permanent throughput or fee penalty. Reduce exposure immediately, migrate activity when needed, then operate in a PQ-native domain for markets and payments.
+            <p class="text-lg mb-8 text-left max-w-3xl" itemprop="description" style="color: var(--fg-80); line-height: 1.75;">
+                The next $300 trillion in tokenized securities, funds, stablecoins, and collateral will choose blockchain rails this decade. EternaX is PQ-native settlement infrastructure: SLH-DSA, the most conservative NIST post-quantum standard, at full market speed. Confidential by cryptography, EVM-compatible from day one, zero migration debt.
             </p>
-
-            <!-- Product Cards -->
-            <div class="grid md:grid-cols-3 gap-6">
-                <div id="product-settlement" class="glass-effect p-6 rounded-lg flex flex-col">
-                    <div class="mb-4">
-                        <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: var(--fg);">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
-                        </svg>
-                    </div>
-                    <div class="font-semibold text-lg mb-3" style="color: var(--fg)">Post-Quantum Settlement and Execution Layer</div>
-                    <p class="text-sm flex-grow" style="color: var(--fg-80)">
-                        PQ-native execution and settlement with auditable privacy and fast finality (~120 ms).
-                    </p>
-                </div>
-                <div id="product-issuance" class="glass-effect p-6 rounded-lg flex flex-col">
-                    <div class="mb-4">
-                        <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: var(--fg);">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                        </svg>
-                    </div>
-                    <div class="font-semibold text-lg mb-3" style="color: var(--fg)">Post-Quantum Issuance and Tokenization Rails (Stablecoins and RWAs)</div>
-                    <p class="text-sm mb-3 flex-grow" style="color: var(--fg-80)">
-                        Day-one PQ-native issuance for stablecoins and RWAs, with issuer-grade mint/burn governance, compliance hooks, and auditable privacy settlement.
-                    </p>
-                    <ul class="text-xs space-y-1" style="color: var(--fg-80)">
-                        <li>Post-Quantum Stablecoin Issuance</li>
-                        <li>Post-Quantum RWA Tokenization and Issuance</li>
-                    </ul>
-                </div>
-                <div id="product-migration" class="glass-effect p-6 rounded-lg flex flex-col">
-                    <div class="mb-4">
-                        <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: var(--fg);">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
-                        </svg>
-                    </div>
-                    <div class="font-semibold text-lg mb-3" style="color: var(--fg)">Post-Quantum Migration and Interoperability Rails</div>
-                    <p class="text-sm mb-3 flex-grow" style="color: var(--fg-80)">
-                        Move assets from existing chains into PQ-native settlement paths via vault and bridge infrastructure.
-                    </p>
-                    <ul class="text-xs space-y-1" style="color: var(--fg-80)">
-                        <li>Post-Quantum Vault (Ethereum / EVM)</li>
-                        <li>Post-Quantum Migration Bridge</li>
-                    </ul>
-                </div>
-                <div id="product-wallet" class="glass-effect p-6 rounded-lg flex flex-col">
-                    <div class="mb-4">
-                        <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: var(--fg);">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-                        </svg>
-                    </div>
-                    <div class="font-semibold text-lg mb-3" style="color: var(--fg)">Post-Quantum Wallet, Custody, and Policy Controls</div>
-                    <p class="text-sm flex-grow" style="color: var(--fg-80)">
-                        PQ signing, wallet policies, custody controls, and agent permissions (KYA-ready).
-                    </p>
-                </div>
-                <div class="flex flex-col items-center justify-center">
-                    <a href="mailto:info@eternax.ai" class="btn-primary px-8 py-4 rounded-lg text-base font-semibold text-center text-white hover:opacity-90 transition-opacity">
-                        Contact us
-                    </a>
-                </div>
-                <div id="product-venues" class="glass-effect p-6 rounded-lg flex flex-col">
-                    <div class="mb-4">
-                        <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: var(--fg);">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
-                        </svg>
-                    </div>
-                    <div class="font-semibold text-lg mb-3" style="color: var(--fg)">Post-Quantum Market Infrastructure Venues</div>
-                    <p class="text-sm mb-3 flex-grow" style="color: var(--fg-80)">
-                        High-velocity trading and information markets powered by PQ-safe collateral and agentic users.
-                    </p>
-                    <ul class="text-xs space-y-1" style="color: var(--fg-80)">
-                        <li>Post-Quantum Perpetuals Exchange (PQ Perps)</li>
-                        <li>Post-Quantum Prediction Markets</li>
-                    </ul>
-                </div>
-                
+            <div class="hero-signals">
+                <span>Compliance-native selective disclosure</span>
+                <span>Supervisory audit without public transparency</span>
+                <span>Institutional custody integration</span>
+                <span>KYC/AML-compatible governance</span>
             </div>
-        </div>
-    </section>
-
-    <!-- Traction Section -->
-    <section class="py-20" style="background-color: var(--bg); border-color: var(--border);">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <!-- Header -->
-            <div class="mb-12">
-                <div class="flex items-center gap-3 mb-2">
-                    <h2 class="text-4xl sm:text-5xl font-semibold tracking-tight" style="color: var(--fg)">
-                        Traction
-            </h2>
-                    <span class="px-3 py-1 rounded-full text-xs font-semibold border" style="border-color: var(--fg); color: var(--fg);">Measured</span>
-                </div>
-                <p class="text-sm" style="color: var(--fg-80)">
-                    As of Nov 2025 testnet window under published counting rules
-                </p>
-            </div>
-
-            <!-- Top Metrics Cards -->
-            <div class="grid md:grid-cols-4 gap-6 mb-16">
-                <div class="glass-effect p-6 rounded-lg">
-                    <div class="text-sm mb-2" style="color: var(--fg-80)">PQ-safe settlement layer</div>
-                    <div class="text-xl font-bold" style="color: var(--fg)">Live on testnet</div>
-                </div>
-                <div class="glass-effect p-6 rounded-lg">
-                    <div class="text-sm mb-2" style="color: var(--fg-80)">Prediction markets</div>
-                    <div class="text-xl font-bold" style="color: var(--fg)">Live on testnet</div>
-                </div>
-                <div class="glass-effect p-6 rounded-lg">
-                    <div class="text-sm mb-2" style="color: var(--fg-80)">On-chain transactions</div>
-                    <div class="text-xl font-bold" style="color: var(--fg);">1,000,000+</div>
-                </div>
-                <div class="glass-effect p-6 rounded-lg">
-                    <div class="text-sm mb-2" style="color: var(--fg-80)">Prediction market bets</div>
-                    <div class="text-xl font-bold" style="color: var(--fg);">475,000+</div>
-                </div>
-            </div>
-
-            <!-- Outcome Mechanics Section -->
             <div>
-                <h3 class="text-3xl sm:text-4xl font-semibold tracking-tight mb-2" style="color: var(--fg)">
-                    Outcome mechanics
-                </h3>
-                <p class="text-sm mb-8" style="color: var(--fg-80)">
-                    From testnet proof to canonical routing:
-                </p>
-                
-                <div class="grid md:grid-cols-2 gap-6">
-                    <div class="glass-effect p-6 rounded-lg">
-                        <div class="font-semibold text-lg mb-3" style="color: var(--fg)">Onboard</div>
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            PQ-native stablecoin and RWA issuance for payments, clearing, and settlement.
-                        </p>
-                    </div>
-                    <div class="glass-effect p-6 rounded-lg">
-                        <div class="font-semibold text-lg mb-3" style="color: var(--fg)">Migrate</div>
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            ETH and EVM tokens into PQ-safe control via PQ vaults plus a PQ-safe bridge. Operate under PQ-native authorization inside EternaX. Redeem back to origin when needed.
-            </p>
+                <a href="mailto:paarrthhh.b@eternax.ai" class="btn-primary inline-block px-8 py-4 rounded-lg text-base font-semibold text-white hover:opacity-90 transition-opacity">Book a Pilot Call</a>
+            </div>
         </div>
-                    <div class="glass-effect p-6 rounded-lg">
-                        <div class="font-semibold text-lg mb-3" style="color: var(--fg)">Trade and pay</div>
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            Prediction markets live. Next: PQ-safe Spot DEX and PQ-safe Perps DEX (roadmap). Payments run on the same PQ-safe settlement rail.
-                        </p>
-    </div>
-                    <div class="glass-effect p-6 rounded-lg">
-                        <div class="font-semibold text-lg mb-3" style="color: var(--fg)">Monetize</div>
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            Venue take-rates (bps-level) plus premium auditable privacy lanes priced for sensitive routing and selective disclosure.
-                        </p>
-                    </div>
+    </section>
+
+    <!-- Metrics Strip -->
+    <section class="py-8 border-y" style="background-color: #ffffff; border-color: #e0dede;">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="hero-metrics">
+                <div class="hero-metrics-item">
+                    <div class="hero-metrics-value accent">Zero</div>
+                    <div class="hero-metrics-label">PQ + Privacy Risk</div>
+                </div>
+                <div class="hero-metrics-item">
+                    <div class="hero-metrics-value">SLH-DSA</div>
+                    <div class="hero-metrics-label">NIST FIPS 205<br>The most conservative PQ standard</div>
+                </div>
+                <div class="hero-metrics-item">
+                    <div class="hero-metrics-value accent">~2%</div>
+                    <div class="hero-metrics-label">PQ TPS Loss<br>vs 84-90% on classical chains</div>
+                </div>
+                <div class="hero-metrics-item">
+                    <div class="hero-metrics-value">50K-200K</div>
+                    <div class="hero-metrics-label">TPS Target<br>Institutional-grade throughput</div>
+                </div>
+                <div class="hero-metrics-item">
+                    <div class="hero-metrics-value">400-520ms</div>
+                    <div class="hero-metrics-label">Hard-Finality Settlement<br>Final execution assurance</div>
                 </div>
             </div>
         </div>
     </section>
 
-     <section class="pt-4 pb-20" style="background-color: var(--bg);">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight mb-6" style="color: var(--fg)">Featured Research Reports</h2>
-        <div class="grid md:grid-cols-2 gap-6">
-          <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="glass-effect p-6 rounded-lg block hover:opacity-90 transition-opacity">
-            <p class="text-xs mb-2" style="color: var(--fg-80)">Research Report · April 2026</p>
-            <h3 class="text-xl font-semibold mb-2" style="color: var(--fg)">Cryptographic Migration Debt Framework</h3>
-            <p class="text-sm" style="color: var(--fg-80)">Institutional post-quantum exposure framework for boards, risk committees, stablecoin issuers, and custodians.</p>
-          </a>
-          <a href="already-broken-quantum-risk-report-q1-2026.html" class="glass-effect p-6 rounded-lg block hover:opacity-90 transition-opacity">
-            <p class="text-xs mb-2" style="color: var(--fg-80)">Research Report · Q1 2026</p>
-            <h3 class="text-xl font-semibold mb-2" style="color: var(--fg)">Already Broken - Quantum Risk Report Q1 2026</h3>
-            <p class="text-sm" style="color: var(--fg-80)">The case that institutional blockchain infrastructure is already at risk under current migration timelines.</p>
-          </a>
+    <!-- Why Now -->
+    <section class="py-12 border-b" style="background-color: #ffffff; border-color: #e0dede;">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <p class="text-xs font-semibold uppercase tracking-widest mb-7" style="color: #2F5E52;">Why now</p>
+            <div class="why-now-strip">
+                <div class="why-now-item">
+                    <div class="why-now-date">March 2026</div>
+                    <p class="why-now-text">Google Quantum AI compressed the qubit threshold to fewer than 500,000 physical qubits.</p>
+                </div>
+                <div class="why-now-item">
+                    <div class="why-now-date">April 2026</div>
+                    <p class="why-now-text">Solana confirmed ~90% throughput loss under PQ migration on a live testnet.</p>
+                </div>
+                <div class="why-now-item">
+                    <div class="why-now-date">January 2027</div>
+                    <p class="why-now-text">NSA CNSA 2.0: all new national security systems must be quantum-safe.</p>
+                </div>
+                <div class="why-now-item">
+                    <div class="why-now-date">2030</div>
+                    <p class="why-now-text">NIST proposed deprecation of ECDSA and EdDSA. The algorithms securing every major blockchain.</p>
+                </div>
+            </div>
         </div>
-      </div>
     </section>
 
-    <!-- Team Section -->
-    <section id="team" class="py-16 border-t" style="background-color: var(--bg); border-color: var(--border);" itemscope itemtype="https://schema.org/Organization" itemprop="member">
+    <!-- Exposure Map -->
+    <section id="exposure" class="py-20" style="background-color: #ffffff;">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="max-w-3xl mb-10">
-                <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight" style="color: var(--fg)">Founding Team</h2>
+            <p class="text-xs font-semibold uppercase tracking-widest mb-4" style="color: #2F5E52;">Post-Quantum Exposure Map</p>
+            <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4 mb-10">
+                <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight" style="color: var(--fg);">Does your institution appear in this report?</h2>
+                <a href="post_quantum_exposure_map_institutional_crypto_tokenized_assets.html" class="text-sm font-semibold whitespace-nowrap" style="color: #2F5E52;">View full Exposure Map with 20+ institutions &rarr;</a>
             </div>
-            <p class="text-lg mb-4" style="color: var(--fg-80)">
-                EternaX is built by researchers and protocol engineers working at the intersection of post-quantum cryptography, confidential execution, high-performance consensus, and coded networking.
-            </p>
-            <p class="text-lg" style="color: var(--fg-80)">
-                Our architecture is anchored in peer-reviewed research and ongoing cryptographic development, ensuring the network evolves with advances in both security and distributed systems.
-            </p>
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+                <div class="glass-effect p-6 rounded-lg"><div class="font-semibold mb-1" style="color: var(--fg);">BlackRock / Securitize</div><div class="text-xs mb-3" style="color: var(--fg-80);">BUIDL tokenized Treasury &middot; ~$2.5B</div><div class="flex justify-between items-start gap-3 mb-3"><span class="text-xs" style="color: var(--fg-80);">Ethereum, multichain &middot; secp256k1</span><span class="text-xs font-semibold px-2 py-1 rounded flex-shrink-0" style="background: rgba(141,46,46,0.08); color: #8D2E2E;">Critical PQ Exposure</span></div><p class="text-xs pt-3 border-t" style="color: var(--fg-80); border-color: #e0dede;">Concentrated admin/transfer-agent keys at Securitize control mint, burn, and whitelist across all share classes. A control-plane compromise propagates to downstream reserves for OUSG and USDtb. No PQ migration disclosed.</p></div>
+                <div class="glass-effect p-6 rounded-lg"><div class="font-semibold mb-1" style="color: var(--fg);">Franklin Templeton</div><div class="text-xs mb-3" style="color: var(--fg-80);">BENJI / FOBXX &middot; $825M &middot; 9 chains</div><div class="flex justify-between items-start gap-3 mb-3"><span class="text-xs" style="color: var(--fg-80);">Ed25519, secp256k1</span><span class="text-xs font-semibold px-2 py-1 rounded flex-shrink-0" style="background: rgba(141,46,46,0.08); color: #8D2E2E;">Critical PQ Exposure</span></div><p class="text-xs pt-3 border-t" style="color: var(--fg-80); border-color: #e0dede;">Transfer agent maintains centralized override across nine public chains. Each new chain deployment compounds migration debt. Nine separate migration problems instead of one.</p></div>
+                <div class="glass-effect p-6 rounded-lg"><div class="font-semibold mb-1" style="color: var(--fg);">Circle / Hashnote</div><div class="text-xs mb-3" style="color: var(--fg-80);">USYC &middot; $313M &middot; 5 chains</div><div class="flex justify-between items-start gap-3 mb-3"><span class="text-xs" style="color: var(--fg-80);">secp256k1, Ed25519</span><span class="text-xs font-semibold px-2 py-1 rounded flex-shrink-0" style="background: rgba(141,46,46,0.08); color: #8D2E2E;">Critical PQ Exposure</span></div><p class="text-xs pt-3 border-t" style="color: var(--fg-80); border-color: #e0dede;">Five chains, each using classical signatures. Two-token model (USYC + USDC redemption) creates interoperability dependencies on Circle attestation services. Attestation and interoperability layers are classical unless a PQ migration has been disclosed.</p></div>
+                <div class="glass-effect p-6 rounded-lg"><div class="font-semibold mb-1" style="color: var(--fg);">State Street / Galaxy</div><div class="text-xs mb-3" style="color: var(--fg-80);">SWEEP Fund &middot; May 2026 on Solana</div><div class="flex justify-between items-start gap-3 mb-3"><span class="text-xs" style="color: var(--fg-80);">Ed25519 &middot; Solana: 90% TPS loss under PQ</span><span class="text-xs font-semibold px-2 py-1 rounded flex-shrink-0" style="background: rgba(141,46,46,0.08); color: #8D2E2E;">Critical PQ Exposure</span></div><p class="text-xs pt-3 border-t" style="color: var(--fg-80); border-color: #e0dede;">Brand-new fund issued on rails that are commercially unviable under PQ. Not legacy exposure. A new-issuance decision made on Solana's Ed25519 architecture after the Solana Foundation's own PQ testing confirmed ~90% throughput loss.</p></div>
+                <div class="glass-effect p-6 rounded-lg"><div class="font-semibold mb-1" style="color: var(--fg);">Ondo Finance</div><div class="text-xs mb-3" style="color: var(--fg-80);">OUSG / Flux &middot; Backed by BUIDL</div><div class="flex justify-between items-start gap-3 mb-3"><span class="text-xs" style="color: var(--fg-80);">Ethereum, XRPL &middot; Stacked dependency</span><span class="text-xs font-semibold px-2 py-1 rounded flex-shrink-0" style="background: rgba(141,46,46,0.08); color: #8D2E2E;">Critical PQ Exposure</span></div><p class="text-xs pt-3 border-t" style="color: var(--fg-80); border-color: #e0dede;">Stacked tokenization: OUSG is backed by BUIDL, then used as sole collateral on Flux. One classical control-plane layer secures another. Breaking the base layer breaks the borrowing layer.</p></div>
+                <div class="glass-effect p-6 rounded-lg"><div class="font-semibold mb-1" style="color: var(--fg);">J.P. Morgan</div><div class="text-xs mb-3" style="color: var(--fg-80);">Kinexys &middot; &gt;$1.5T processed</div><div class="flex justify-between items-start gap-3 mb-3"><span class="text-xs" style="color: var(--fg-80);">Private DLT &middot; Classical enterprise crypto</span><span class="text-xs font-semibold px-2 py-1 rounded flex-shrink-0" style="background: rgba(141,46,46,0.05); color: #a0544c;">Elevated PQ Exposure</span></div><p class="text-xs pt-3 border-t" style="color: var(--fg-80); border-color: #e0dede;">Not public-chain theft. Control-plane-heavy: bank admin keys, KMS, and legal continuity across tokenized deposits. Migration requires re-papering across banks, funds, and client books.</p></div>
+            </div>
+            <p class="text-sm max-w-3xl" style="color: var(--fg-80);"><strong style="color: var(--fg);">If your institution, product, or chain appears in this report,</strong> your next issuance decision is the one that matters most. New products launched on classical rails today will require migration tomorrow. EternaX eliminates that liability from day one. <a href="post_quantum_exposure_map_institutional_crypto_tokenized_assets.html" class="font-semibold" style="color: #2F5E52;">Read the full report &rarr;</a></p>
+        </div>
+    </section>
+
+    <!-- Brand Statement -->
+    <section class="py-16 border-t text-center" style="border-color: #e0dede;">
+        <div class="max-w-3xl mx-auto px-4">
+            <p class="text-xl sm:text-2xl font-semibold leading-relaxed" style="color: var(--fg);">The problem is <span style="color: #2F5E52;">named</span>. The science is <span style="color: #2F5E52;">published</span>. The infrastructure is <span style="color: #2F5E52;">live</span>.</p>
+        </div>
+    </section>
+
+    <!-- Three Pillars -->
+    <section id="pillars" class="py-20">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <p class="text-xs font-semibold uppercase tracking-widest mb-4" style="color: #2F5E52;">Three institutional requirements. One chain.</p>
+            <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight mb-4 max-w-2xl" style="color: var(--fg);">Privacy. Composability. Post-quantum security. All native.</h2>
+            <p class="text-lg mb-12 max-w-2xl" style="color: var(--fg-80);">Each alone exists elsewhere. No production infrastructure delivers all three simultaneously. EternaX does, from block zero.</p>
+            <div class="grid md:grid-cols-3 gap-6">
+                <div class="glass-effect p-6 rounded-lg"><div class="mb-4"><svg class="w-8 h-8" fill="none" stroke="#2F5E52" stroke-width="1.5" viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg></div><h3 class="font-semibold text-lg mb-3" style="color: var(--fg);">Quantum-Durable Institutional Privacy</h3><p class="text-sm" style="color: var(--fg-80);">Counterparties, treasury movements, and collateral positions stay confidential by cryptography, not by access control. Regulators and auditors can receive scoped disclosures for supervision, compliance, and verification. Designed to eliminate public-order-flow MEV. Privacy built for the post-quantum era.</p></div>
+                <div class="glass-effect p-6 rounded-lg"><div class="mb-4"><svg class="w-8 h-8" fill="none" stroke="#2F5E52" stroke-width="1.5" viewBox="0 0 24 24"><rect x="2" y="3" width="8" height="8" rx="1.5"/><rect x="14" y="3" width="8" height="8" rx="1.5"/><rect x="8" y="13" width="8" height="8" rx="1.5"/><path d="M6 11v2a2 2 0 002 2M18 11v2a2 2 0 01-2 2"/></svg></div><h3 class="font-semibold text-lg mb-3" style="color: var(--fg);">Your Existing Smart Contracts Deploy Directly</h3><p class="text-sm" style="color: var(--fg-80);">EVM-compatible. Your Solidity protocols, lending markets, collateral management, and settlement logic deploy with minimal modifications and automatically inherit quantum-safe security and institutional privacy. No cold-start problem. No new developer ecosystem to build.</p></div>
+                <div class="glass-effect p-6 rounded-lg"><div class="mb-4"><svg class="w-8 h-8" fill="none" stroke="#2F5E52" stroke-width="1.5" viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg></div><h3 class="font-semibold text-lg mb-3" style="color: var(--fg);">The Most Conservative PQ Scheme at Market Speed</h3><p class="text-sm" style="color: var(--fg-80);">SLH-DSA (NIST FIPS 205): hash-function security studied since 1979, zero algebraic assumptions, zero successful attacks. Dilithium and Falcon rely on younger lattice math — if it weakens, both break simultaneously, forcing a second migration. SLH-DSA eliminates that tail risk. SILMARILS (arXiv:2605.03230, UBC + EternaX Labs): 160-byte authentication that makes the conservative choice viable at market speed. Hash-only from genesis.</p></div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Stat Break -->
+    <section class="py-20" style="background-color: var(--fg); color: #ffffff;">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="stat-break-grid mb-12">
+                <div>
+                    <h3 class="text-xs font-semibold uppercase tracking-widest mb-6 text-center" style="color: rgba(255,255,255,0.7);">The PQC Signature Size Problem</h3>
+                    <div class="overflow-x-auto">
+                        <table class="w-full text-sm">
+                            <thead><tr class="text-xs uppercase tracking-wide" style="color: rgba(255,255,255,0.55);"><th class="text-left pb-3">Scheme</th><th class="text-right pb-3">Size</th><th class="text-right pb-3">vs Classical</th></tr></thead>
+                            <tbody style="color: #fff;">
+                                <tr><td colspan="3" class="pt-4 pb-2 text-xs uppercase" style="color: rgba(255,255,255,0.55);">Classical (what blockchains use today)</td></tr>
+                                <tr class="border-b" style="border-color: rgba(255,255,255,0.08);"><td class="py-2">ECDSA <span class="text-xs" style="color: rgba(255,255,255,0.55);">Ethereum</span></td><td class="py-2 text-right font-semibold">64 B</td><td class="py-2 text-right font-semibold">1x</td></tr>
+                                <tr class="border-b" style="border-color: rgba(255,255,255,0.08);"><td class="py-2">Ed25519 <span class="text-xs" style="color: rgba(255,255,255,0.55);">Solana</span></td><td class="py-2 text-right font-semibold">64 B</td><td class="py-2 text-right font-semibold">1x</td></tr>
+                                <tr><td colspan="3" class="pt-4 pb-2 text-xs uppercase" style="color: rgba(255,255,255,0.55);">Post-quantum alternatives</td></tr>
+                                <tr class="border-b" style="border-color: rgba(255,255,255,0.08);"><td class="py-2">FN-DSA <span class="text-xs" style="color: rgba(255,255,255,0.55);">Falcon</span></td><td class="py-2 text-right font-semibold">666 B</td><td class="py-2 text-right font-semibold">10x</td></tr>
+                                <tr class="border-b" style="border-color: rgba(255,255,255,0.08);"><td class="py-2">ML-DSA <span class="text-xs" style="color: rgba(255,255,255,0.55);">Dilithium</span></td><td class="py-2 text-right font-semibold">2,420 B</td><td class="py-2 text-right font-semibold">38x</td></tr>
+                                <tr><td colspan="3" class="pt-4 pb-2 text-xs uppercase" style="color: rgba(255,255,255,0.55);">Most conservative NIST standard</td></tr>
+                                <tr><td class="py-2">SLH-DSA <span class="text-xs" style="color: rgba(255,255,255,0.55);">SPHINCS+</span></td><td class="py-2 text-right font-semibold">7,856 B</td><td class="py-2 text-right font-semibold">123x</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p class="text-xs mt-4 text-center" style="color: rgba(255,255,255,0.55);">Every transaction carries a signature. Multiply by thousands of TPS.<br>Signature size becomes throughput loss.</p>
+                </div>
+                <div>
+                    <h3 class="text-xs font-semibold uppercase tracking-widest mb-6 text-center" style="color: rgba(255,255,255,0.7);">Throughput loss under PQ migration</h3>
+                    <div class="space-y-5">
+                        <div><div class="flex items-center justify-between mb-2"><span class="font-semibold">EternaX</span><span class="font-semibold" style="color: #6EECC0;">~2%</span></div><div class="relative h-8 rounded-sm overflow-hidden" style="background-color: rgba(255,255,255,0.12);"><div class="h-full rounded-sm" style="background-color: #6EECC0; width: 2%;"></div></div><p class="text-xs mt-1" style="color: rgba(255,255,255,0.55);">SLH-DSA + SILMARILS</p></div>
+                        <div><div class="flex items-center justify-between mb-2"><span class="font-semibold">Ethereum</span><span class="font-semibold">~84%</span></div><div class="relative h-8 rounded-sm overflow-hidden" style="background-color: rgba(255,255,255,0.12);"><div class="h-full rounded-sm" style="background-color: #F08080; width: 84%;"></div></div><p class="text-xs mt-1" style="color: rgba(255,255,255,0.55);">Modeled retrofit loss</p></div>
+                        <div><div class="flex items-center justify-between mb-2"><span class="font-semibold">Canton</span><span class="font-semibold">~88%</span></div><div class="relative h-8 rounded-sm overflow-hidden" style="background-color: rgba(255,255,255,0.12);"><div class="h-full rounded-sm" style="background-color: #F08080; width: 88%;"></div></div><p class="text-xs mt-1" style="color: rgba(255,255,255,0.55);">Modeled retrofit loss</p></div>
+                        <div><div class="flex items-center justify-between mb-2"><span class="font-semibold">Solana</span><span class="font-semibold">~90%</span></div><div class="relative h-8 rounded-sm overflow-hidden" style="background-color: rgba(255,255,255,0.12);"><div class="h-full rounded-sm" style="background-color: #F08080; width: 90%;"></div></div><p class="text-sm mt-2 pl-3 border-l-2 font-semibold" style="border-color: #6EECC0; color: #6EECC0;">Confirmed by Project Eleven &amp; Solana Foundation on a live PQ testnet, April 2026.</p></div>
+                        <div><div class="flex items-center justify-between mb-2"><span class="font-semibold">Stellar</span><span class="font-semibold">~90%</span></div><div class="relative h-8 rounded-sm overflow-hidden" style="background-color: rgba(255,255,255,0.12);"><div class="h-full rounded-sm" style="background-color: #F08080; width: 90%;"></div></div><p class="text-xs mt-1" style="color: rgba(255,255,255,0.55);">Modeled retrofit loss</p></div>
+                    </div>
+                </div>
+            </div>
+            <div class="text-center max-w-3xl mx-auto">
+                <p class="text-lg font-semibold mb-4">The most conservative post-quantum foundation. At market speed. From day one.</p>
+                <p class="text-sm" style="color: rgba(255,255,255,0.8);">Every other chain faces an impossible choice: weaker lattice-based schemes (ML-DSA, FN-DSA) with ongoing cryptographic risk, or conservative SLH-DSA with 84-90% throughput loss. On EternaX, the trade-off is resolved. Full SLH-DSA security. ~2% loss. Settlement continues.</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTA -->
+    <section id="contact" class="py-20 border-b" style="border-color: #e0dede;">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <p class="text-xs font-semibold uppercase tracking-widest mb-4" style="color: #2F5E52;">Get Started</p>
+            <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight mb-10 max-w-3xl" style="color: var(--fg);">The cost of choosing PQ-native now is near zero.<br>The cost of migrating later is not.</h2>
+            <div class="grid md:grid-cols-2 gap-6">
+                <div class="cta-card glass-effect rounded-lg">
+                    <h3 class="text-lg font-semibold mb-3" style="color: var(--fg);">For Institutions</h3>
+                    <p class="text-sm mb-6" style="color: var(--fg-80); line-height: 1.65;">Every week on classical rails compounds cryptographic debt that PQ-native rails will never carry. The first issuer to claim "post-quantum-native from day one, quantum-durable privacy, zero migration debt" gains a trust advantage competitors on classical rails cannot replicate.</p>
+                    <ol class="cta-steps">
+                        <li><span class="num">01</span><span><a href="post_quantum_exposure_map_institutional_crypto_tokenized_assets.html" class="font-semibold" style="color: #2F5E52;">Find your institution</a> in the Post-Quantum Exposure Map</span></li>
+                        <li><span class="num">02</span><span>Forward the findings to your risk committee and CTO</span></li>
+                        <li><span class="num">03</span><span><a href="mailto:paarrthhh.b@eternax.ai" class="font-semibold" style="color: #2F5E52;">Schedule a pilot call</a> to evaluate PQ-native issuance</span></li>
+                    </ol>
+                    <div class="cta-links">
+                        <a href="mailto:paarrthhh.b@eternax.ai" class="btn-cta btn-primary text-white">Book a Pilot Call</a>
+                        <a href="why-eternax.html" class="btn-cta btn-cta-secondary">Architecture Overview</a>
+                    </div>
+                </div>
+                <div class="cta-card glass-effect rounded-lg">
+                    <h3 class="text-lg font-semibold mb-3" style="color: var(--fg);">For Investors</h3>
+                    <p class="text-sm mb-6" style="color: var(--fg-80); line-height: 1.65;">Seed round open. Bootstrapped to date. Category-defining infrastructure thesis backed by published science and four institutional research reports.</p>
+                    <div class="cta-links mb-6">
+                        <a href="mailto:paarrthhh.b@eternax.ai" class="btn-cta btn-primary text-white">Schedule a Call</a>
+                        <a href="https://arxiv.org/abs/2605.03230" class="btn-cta btn-cta-secondary">SILMARILS Paper</a>
+                        <a href="why-eternax.html" class="btn-cta btn-cta-secondary">Investment Thesis</a>
+                    </div>
+                    <p class="text-xs mb-3 font-mono" style="color: var(--fg-80); line-height: 1.55;">Capital deploys to: mainnet launch, institutional pilot programme, first PQ-native stablecoin issuance.</p>
+                    <p class="text-xs" style="color: var(--fg-80);"><a href="mailto:paarrthhh.b@eternax.ai" class="link-muted">paarrthhh.b@eternax.ai</a>&ensp;&ensp;<a href="mailto:dariia.p@eternax.ai" class="link-muted">dariia.p@eternax.ai</a></p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Use Cases -->
+    <section id="usecases" class="py-20" style="background-color: #ffffff;">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <p class="text-xs font-semibold uppercase tracking-widest mb-4" style="color: #2F5E52;">Institutional Use Cases</p>
+            <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight mb-10 max-w-4xl" style="color: var(--fg);">Every new issuance is a rail decision. Choose the rail that avoids classical-to-post-quantum migration debt.</h2>
+            <div class="use-cases-strip">
+                <div class="use-cases-item">
+                    <h3 class="font-semibold mb-3" style="color: var(--fg);">Stablecoin Issuance</h3>
+                    <p class="text-sm mb-4" style="color: var(--fg-80);">PQ-native from day one. Auditable privacy for treasury operations. Compliance-native selective disclosure. EVM-compatible mint/burn governance.</p>
+                    <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="text-xs font-semibold" style="color: #2F5E52;">Migration Debt Framework &rarr;</a>
+                </div>
+                <div class="use-cases-item">
+                    <h3 class="font-semibold mb-3" style="color: var(--fg);">Tokenized Funds and RWAs</h3>
+                    <p class="text-sm mb-4" style="color: var(--fg-80);">One PQ-native chain replaces multi-chain classical deployments. One compliance surface. One custody integration. One migration surface instead of nine.</p>
+                    <a href="post-quantum-signature-security-ranking-2026.html" class="text-xs font-semibold" style="color: #2F5E52;">PQ Signature Ranking &rarr;</a>
+                </div>
+                <div class="use-cases-item">
+                    <h3 class="font-semibold mb-3" style="color: var(--fg);">Collateral and Settlement</h3>
+                    <p class="text-sm mb-4" style="color: var(--fg-80);">PQ-native collateral tokenization, movement, and settlement. T+0 at 400-520ms hard finality. No classical key dependency at any layer.</p>
+                    <a href="mailto:paarrthhh.b@eternax.ai" class="text-xs font-semibold" style="color: #2F5E52;">Discuss a pilot &rarr;</a>
+                </div>
+                <div class="use-cases-item">
+                    <h3 class="font-semibold mb-3" style="color: var(--fg);">Migration from Existing Chains</h3>
+                    <p class="text-sm mb-4" style="color: var(--fg-80);">PQ vaults and bridge infrastructure. Move assets from Ethereum/EVM into PQ-native settlement. Operate under quantum-safe authorization. Redeem back when needed.</p>
+                    <a href="already-broken-quantum-risk-report-q1-2026.html" class="text-xs font-semibold" style="color: #2F5E52;">Already Broken Report &rarr;</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Evidence -->
+    <section id="proof" class="py-20">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <p class="text-xs font-semibold uppercase tracking-widest mb-4" style="color: #2F5E52;">Evidence</p>
+            <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight mb-10" style="color: var(--fg);">Research-backed. Testnet-proven. Publication-validated.</h2>
+            <div class="grid md:grid-cols-2 gap-4 mb-4">
+                <div class="glass-effect p-6 rounded-lg">
+                    <p class="text-xs font-semibold uppercase tracking-widest mb-4" style="color: #2F5E52;">Published Research</p>
+                    <p class="font-semibold mb-2" style="color: var(--fg);">SILMARILS: Designated-Verifier Authentication with Information-Theoretic Security</p>
+                    <p class="text-sm mb-4" style="color: var(--fg-80);">arXiv:2605.03230, May 2026. UBC School of Engineering + EternaX Labs. Formal proofs in ROM, QROM, and pure IT model. Open-source Rust implementation with benchmarks.</p>
+                    <p class="text-sm"><a href="https://arxiv.org/abs/2605.03230" class="font-semibold" style="color: #2F5E52;">Read on arXiv &rarr;</a>&ensp;&ensp;<a href="https://github.com/eternax-ai" class="font-semibold" style="color: #2F5E52;">GitHub &rarr;</a></p>
+                </div>
+                <div class="glass-effect p-6 rounded-lg">
+                    <p class="text-xs font-semibold uppercase tracking-widest mb-4" style="color: #2F5E52;">Credibility</p>
+                    <p class="text-sm" style="color: var(--fg-80);">Peer-reviewed: SILMARILS published via UBC School of Engineering, May 2026. Dr. Chen Feng — UBC Principal's Research Chair, PhD Toronto, 100+ peer-reviewed papers, SILMARILS co-author. Dariia Porechna — cryptographer, ex-Wolfram|Alpha, ex-Subspace Protocol lead, SILMARILS co-author. Paarrthhh Birla — ex-Polygon VP Growth, digital-assets advisory at Visa and State Street. Institutional PQ briefings delivered to FINRA and AMINA Bank AG (FINMA-licensed). Bootstrapped to date. Open-source Rust codebase on GitHub.</p>
+                </div>
+            </div>
+            <div class="evidence-reports mb-8">
+                <a href="post_quantum_exposure_map_institutional_crypto_tokenized_assets.html" class="glass-effect p-4 rounded-lg block hover:opacity-90 transition-opacity">
+                    <div class="text-sm font-semibold mb-1" style="color: var(--fg);">Post-Quantum Exposure Map 2026</div>
+                    <div class="text-xs" style="color: var(--fg-80);">May 2026 &middot; 20+ institutions</div>
+                    <span class="text-xs font-semibold mt-3 inline-block" style="color: #2F5E52;">&rarr;</span>
+                </a>
+                <a href="post-quantum-signature-security-ranking-2026.html" class="glass-effect p-4 rounded-lg block hover:opacity-90 transition-opacity">
+                    <div class="text-sm font-semibold mb-1" style="color: var(--fg);">PQ Signature Security Ranking</div>
+                    <div class="text-xs" style="color: var(--fg-80);">May 2026 &middot; All 12 NIST schemes</div>
+                    <span class="text-xs font-semibold mt-3 inline-block" style="color: #2F5E52;">&rarr;</span>
+                </a>
+                <a href="post-quantum-cryptography-risk-framework-for-institutions.html" class="glass-effect p-4 rounded-lg block hover:opacity-90 transition-opacity">
+                    <div class="text-sm font-semibold mb-1" style="color: var(--fg);">Cryptographic Migration Debt</div>
+                    <div class="text-xs" style="color: var(--fg-80);">Apr 2026 &middot; $112M-$295M/institution</div>
+                    <span class="text-xs font-semibold mt-3 inline-block" style="color: #2F5E52;">&rarr;</span>
+                </a>
+                <a href="already-broken-quantum-risk-report-q1-2026.html" class="glass-effect p-4 rounded-lg block hover:opacity-90 transition-opacity">
+                    <div class="text-sm font-semibold mb-1" style="color: var(--fg);">Already Broken</div>
+                    <div class="text-xs" style="color: var(--fg-80);">Q1 2026 &middot; 27 institutions, 0 PQ plans</div>
+                    <span class="text-xs font-semibold mt-3 inline-block" style="color: #2F5E52;">&rarr;</span>
+                </a>
+            </div>
+            <div class="hero-metrics hero-metrics--4 mb-8 py-6 border-y" style="border-color: #e0dede;">
+                <div class="hero-metrics-item">
+                    <div class="hero-metrics-value">50K-200K</div>
+                    <div class="hero-metrics-label">TPS target</div>
+                </div>
+                <div class="hero-metrics-item">
+                    <div class="hero-metrics-value accent">~2%</div>
+                    <div class="hero-metrics-label">PQ throughput loss</div>
+                </div>
+                <div class="hero-metrics-item">
+                    <div class="hero-metrics-value">SLH-DSA</div>
+                    <div class="hero-metrics-label">PQ security anchor</div>
+                </div>
+                <div class="hero-metrics-item">
+                    <div class="hero-metrics-value">400-520ms</div>
+                    <div class="hero-metrics-label">Hard-finality settlement</div>
+                </div>
+            </div>
+            <div class="glass-effect p-4 rounded-lg flex items-center gap-4">
+                <span class="w-2 h-2 rounded-full flex-shrink-0" style="background-color: #2F5E52;"></span>
+                <span class="text-sm flex-1" style="color: var(--fg-80);">Testnet live since November 2025. 1M+ transactions. 475K+ prediction market bets.</span>
+            </div>
+        </div>
+    </section>
+
+    <!-- Team -->
+    <section id="team" class="py-16 border-t" style="background-color: #ffffff; border-color: #e0dede;" itemscope itemtype="https://schema.org/Organization" itemprop="member">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <p class="text-xs font-semibold uppercase tracking-widest mb-4" style="color: #2F5E52;">Founding Team</p>
+            <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight mb-10 max-w-4xl" style="color: var(--fg);">10+ years at the intersection of blockchain infrastructure, institutional finance, and post-quantum cryptography</h2>
             <div class="grid gap-6 sm:gap-8 md:grid-cols-3">
                 <div class="glass-effect p-6 rounded-lg">
-                    <div class="flex justify-center mb-3">
-                        <img src="./assets/dariia.png" alt="Dariia Porechna" class="w-32 h-32 rounded-full object-cover" loading="lazy" itemprop="image">
-                    </div>
-                    <div class="font-semibold mb-1" style="color: var(--fg-90)">Dariia Porechna</div>
-                    <div class="text-sm mb-4" style="color: var(--fg-80)">
-                        Cryptographer and distributed systems architect; Head of Protocol, Subspace; Research Engineer, Wolfram|Alpha. Co-author, SILMARILS.
-                    </div>
-                    <div class="flex gap-2">
-                        <a href="https://www.linkedin.com/in/dariia-porechna" target="_blank" rel="noopener noreferrer" class="link-muted" aria-label="Dariia Porechna on LinkedIn">
-                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                                <path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1 4.98 2.12 4.98 3.5ZM.5 8.5h4V22h-4V8.5Zm7 0h3.83v1.84h.05c.53-1 1.83-2.06 3.77-2.06 4.03 0 4.78 2.65 4.78 6.1V22h-4v-5.72c0-1.36-.03-3.11-1.9-3.11-1.9 0-2.19 1.49-2.19 3.02V22h-4V8.5Z"/>
-                            </svg>
-                        </a>
-                        <a href="https://x.com/FutureDies" target="_blank" rel="noopener noreferrer" class="link-muted" aria-label="Dariia Porechna on X">
-                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                                <path d="M18.244 2H21l-6.5 7.43L22 22h-6.828l-5.34-7.094L3.5 22H1l7.066-8.082L2 2h6.828l4.951 6.55L18.244 2Zm-2.4 18h2.4L8.16 4H5.76l10.083 16Z"/>
-                            </svg>
-                        </a>
+                    <div class="flex justify-center mb-3"><img src="./assets/dariia.png" alt="Dariia Porechna" class="w-32 h-32 rounded-full object-cover" loading="lazy" itemprop="image"></div>
+                    <div class="font-semibold mb-1 text-center" style="color: var(--fg);">Dariia Porechna</div>
+                    <div class="text-xs font-semibold uppercase tracking-widest mb-4 text-center" style="color: #2F5E52;">Co-Founder</div>
+                    <div class="text-sm mb-4 text-center" style="color: var(--fg-80);">Cryptographer and distributed systems architect; Head of Protocol, Subspace; Research Engineer, Wolfram|Alpha. Co-author, SILMARILS.</div>
+                    <div class="flex justify-center gap-3"><a href="https://www.linkedin.com/in/dariia-porechna" target="_blank" rel="noopener noreferrer" class="text-xs font-semibold" style="color: #2F5E52;">LinkedIn</a><a href="https://x.com/FutureDies" target="_blank" rel="noopener noreferrer" class="text-xs font-semibold" style="color: #2F5E52;">X</a></div>
+                </div>
+                <div class="glass-effect p-6 rounded-lg">
+                    <div class="flex justify-center mb-3"><img src="./assets/parthh.png" alt="Paarrthhh Birla" class="w-32 h-32 rounded-full object-cover" loading="lazy" itemprop="image"></div>
+                    <div class="font-semibold mb-1 text-center" style="color: var(--fg);">Paarrthhh Birla</div>
+                    <div class="text-xs font-semibold uppercase tracking-widest mb-4 text-center" style="color: #2F5E52;">Co-Founder</div>
+                    <div class="text-sm mb-4 text-center" style="color: var(--fg-80);">Ex-Polygon (VP Growth Office); Head of Partnerships, Subspace Protocol; Digital assets strategy at EYP, Advised Visa and State Street; MBA, CPA.</div>
+                    <div class="flex justify-center gap-3"><a href="https://www.linkedin.com/in/paarrthhh-birla-b3607bb4/" target="_blank" rel="noopener noreferrer" class="text-xs font-semibold" style="color: #2F5E52;">LinkedIn</a><a href="https://x.com/parthweb34ai" target="_blank" rel="noopener noreferrer" class="text-xs font-semibold" style="color: #2F5E52;">X</a></div>
+                </div>
+                <div class="glass-effect p-6 rounded-lg">
+                    <div class="flex justify-center mb-3"><img src="./assets/chen.png" alt="Dr. Chen Feng" class="w-32 h-32 rounded-full object-cover" loading="lazy" itemprop="image"></div>
+                    <div class="font-semibold mb-1 text-center" style="color: var(--fg);">Dr. Chen Feng</div>
+                    <div class="text-xs font-semibold uppercase tracking-widest mb-4 text-center" style="color: #2F5E52;">Chief Scientist</div>
+                    <div class="text-sm mb-4 text-center" style="color: var(--fg-80);">Assoc. Prof. at University of British Columbia; PhD (Toronto); 100+ peer-reviewed papers; Quantum communications, blockchain, TEE privacy. Co-author, SILMARILS.</div>
+                    <div class="flex justify-center gap-3"><a href="https://www.linkedin.com/in/chen-feng-75272a37" target="_blank" rel="noopener noreferrer" class="text-xs font-semibold" style="color: #2F5E52;">LinkedIn</a><a href="https://scholar.google.com/citations?user=D8b0l-EAAAAJ" target="_blank" rel="noopener noreferrer" class="text-xs font-semibold" style="color: #2F5E52;">Scholar</a></div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Closing CTA -->
+    <section class="py-16 border-t border-b text-center" style="border-color: #e0dede;">
+        <div class="max-w-3xl mx-auto px-4">
+            <p class="text-xl sm:text-2xl font-semibold mb-8" style="color: var(--fg);">Ready to evaluate PQ-native issuance for your institution?</p>
+            <a href="mailto:paarrthhh.b@eternax.ai" class="btn-primary inline-block px-8 py-4 rounded-lg text-base font-semibold text-white hover:opacity-90 transition-opacity">Book a Pilot Call</a>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section id="faq" class="py-16 border-t" style="background-color: var(--bg); border-color: var(--border);">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <p class="text-xs font-semibold uppercase tracking-widest mb-4" style="color: #2F5E52;">FAQ</p>
+            <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight mb-4" style="color: var(--fg);">Institutional post-quantum blockchain FAQ</h2>
+            <p class="text-lg mb-12" style="color: var(--fg-80);">Answers for stablecoin issuers, RWA platforms, tokenized fund managers, custodians, banks, risk committees, auditors, compliance teams, and investors evaluating PQ-native issuance, auditable privacy, EVM-compatible settlement, post-quantum throughput, and cryptographic migration debt.</p>
+            <div class="divide-y" style="border-color: var(--border);">
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">What problem does EternaX solve for institutions?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">EternaX solves the new-issuance problem for institutional digital assets. Stablecoins, RWAs, tokenized funds, collateral systems, and settlement workflows launched on classical blockchain rails inherit future post-quantum migration debt. EternaX lets institutions issue and settle assets on PQ-native rails from day one, with auditable privacy, EVM compatibility, and market-speed finality.</p>
                     </div>
                 </div>
-                
-                <div class="glass-effect p-6 rounded-lg">
-                    <div class="flex justify-center mb-3">
-                        <img src="./assets/parthh.png" alt="Paarrthhh Birla" class="w-32 h-32 rounded-full object-cover" loading="lazy" itemprop="image">
-                    </div>
-                    <div class="font-semibold mb-1" style="color: var(--fg-90)">Paarrthhh Birla</div>
-                    <div class="text-sm mb-4" style="color: var(--fg-80)">
-                        Ex-Polygon (VP Growth Office); Head of Partnerships, Subspace Protocol; Digital assets strategy at EYP; MBA, CPA
-                    </div>
-                    <div class="flex gap-2">
-                        <a href="https://www.linkedin.com/in/paarrthhh-birla-b3607bb4/" target="_blank" rel="noopener noreferrer" class="link-muted" aria-label="Paarrthhh Birla on LinkedIn">
-                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                                <path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1 4.98 2.12 4.98 3.5ZM.5 8.5h4V22h-4V8.5Zm7 0h3.83v1.84h.05c.53-1 1.83-2.06 3.77-2.06 4.03 0 4.78 2.65 4.78 6.1V22h-4v-5.72c0-1.36-.03-3.11-1.9-3.11-1.9 0-2.19 1.49-2.19 3.02V22h-4V8.5Z"/>
-                            </svg>
-                        </a>
-                        <a href="https://x.com/parthweb34ai" target="_blank" rel="noopener noreferrer" class="link-muted" aria-label="Paarrthhh Birla on X">
-                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                                <path d="M18.244 2H21l-6.5 7.43L22 22h-6.828l-5.34-7.094L3.5 22H1l7.066-8.082L2 2h6.828l4.951 6.55L18.244 2Zm-2.4 18h2.4L8.16 4H5.76l10.083 16Z"/>
-                            </svg>
-                        </a>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">What is EternaX?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">EternaX is a PQ-native, EVM-compatible Layer 1 blockchain for institutional settlement, stablecoin issuance, RWA tokenization, tokenized funds, collateral movement, and migration from classical chains. It combines SLH-DSA/SPHINCS+ as the conservative post-quantum security anchor, SILMARILS for compact transaction authentication, auditable privacy for institutional flows, and market-speed settlement for production financial infrastructure.</p>
                     </div>
                 </div>
-                
-                <div class="glass-effect p-6 rounded-lg">
-                    <div class="flex justify-center mb-3">
-                        <img src="./assets/chen.png" alt="Dr. Chen Feng" class="w-32 h-32 rounded-full object-cover" loading="lazy" itemprop="image">
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">Who should evaluate EternaX before issuing digital assets?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">Stablecoin issuers, RWA platforms, tokenized fund managers, banks, custodians, exchanges, prime brokers, collateral venues, payment networks, asset managers, and digital-asset infrastructure teams should evaluate EternaX before launching a new product or expanding an existing product to another classical chain.</p>
                     </div>
-                    <div class="font-semibold mb-1" style="color: var(--fg-90)">Dr. Chen Feng</div>
-                    <div class="text-sm mb-4" style="color: var(--fg-80)">
-                        Assoc. Prof. at University of British Columbia; PhD (Toronto); 100+ peer-reviewed papers; Quantum communications, blockchain, TEE privacy. Co-author, SILMARILS.
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">What can an institution pilot first on EternaX?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">The cleanest first pilot is a PQ-native issuance or settlement workflow: a stablecoin wrapper, tokenized fund share class, RWA test issuance, collateral movement flow, custody-policy flow, private settlement corridor, or Solidity-based DeFi contract deployed on EternaX testnet. The goal is to prove post-quantum authorization, auditable privacy, and settlement performance before a production rail decision hardens.</p>
                     </div>
-                    <div class="flex gap-2">
-                        <a href="https://www.linkedin.com/in/chen-feng-75272a37" target="_blank" rel="noopener noreferrer" class="link-muted" aria-label="Dr. Chen Feng on LinkedIn">
-                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                                <path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1 4.98 2.12 4.98 3.5ZM.5 8.5h4V22h-4V8.5Zm7 0h3.83v1.84h.05c.53-1 1.83-2.06 3.77-2.06 4.03 0 4.78 2.65 4.78 6.1V22h-4v-5.72c0-1.36-.03-3.11-1.9-3.11-1.9 0-2.19 1.49-2.19 3.02V22h-4V8.5Z"/>
-                            </svg>
-                        </a>
-                        <a href="https://scholar.google.com/citations?user=D8b0l-EAAAAJ" target="_blank" rel="noopener noreferrer" class="link-muted" aria-label="Dr. Chen Feng on Google Scholar">
-                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                                <path d="M12 2l10 6-10 6-10-6 10-6Zm0 8l10 6-10 6-10-6 10-6Z"/>
-                            </svg>
-                        </a>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">Is EternaX for new issuance, legacy migration, or both?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">Both, but the highest-value starting point is new issuance. Legacy assets require exposure mapping, admin-key hardening, vendor PQ roadmap review, and coordinated migration planning. New issuance is cleaner: institutions can avoid creating fresh cryptographic migration debt by issuing stablecoins, RWAs, funds, and collateral instruments on PQ-native rails from day one.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">Does EternaX require abandoning Ethereum, Solana, Canton, or existing infrastructure?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">No. EternaX can complement existing infrastructure. Institutions can keep legacy assets where they are, deploy EVM-compatible contracts on EternaX, test PQ-native issuance, build migration rails, and route selected settlement, collateral, or custody workflows through post-quantum infrastructure without immediately abandoning existing systems.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">Is EternaX EVM compatible?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">Yes. EternaX is EVM-compatible, so existing Solidity contracts, token contracts, DeFi protocols, custody-policy logic, collateral workflows, and settlement applications can deploy with minimal modifications. Institutions do not need to rebuild an entirely new developer stack to test PQ-native issuance or settlement.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">What is EternaX's throughput and settlement speed?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">EternaX targets 50,000-200,000 TPS, approximately 2% PQ throughput overhead, 20-50ms soft finality, and 400-520ms hard-finality settlement for institutional market-infrastructure workloads. The point is not raw TPS marketing; it is post-quantum security without collapsing settlement capacity, collateral movement, redemptions, or EVM-compatible execution.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">What makes EternaX a post-quantum-native blockchain?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">EternaX is post-quantum-native because its core authorization path contains zero classical signature primitives such as ECDSA, Ed25519, BLS, or KZG. It uses SLH-DSA/SPHINCS+ as the conservative post-quantum security anchor and SILMARILS for compact transaction authentication, enabling PQ-native operation without the large throughput collapse associated with retrofit paths.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">Why does EternaX use SLH-DSA/SPHINCS+ instead of Dilithium, Falcon, or other lattice-based schemes?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">SLH-DSA is the only NIST-standardized post-quantum signature scheme whose security relies entirely on hash functions — a mathematical primitive studied since 1979 with zero successful attacks. Dilithium (ML-DSA) and Falcon(FN-DSA) rely on lattice-based algebraic assumptions (Module-LWE and NTRU) that are decades younger and face active cryptanalytic research. For an institution issuing stablecoins, tokenized funds, or settlement rails expected to survive 20-30 years of cryptographic scrutiny, this distinction is not academic — it is a fiduciary question. If lattice assumptions weaken or break, every asset authorized by Dilithium or Falcon requires emergency re-keying and migration — a second cryptographic migration crisis layered on top of the classical-to-PQ migration institutions already face. SLH-DSA eliminates that tail risk entirely. Falcon carries additional implementation risk: it requires complex floating-point arithmetic during signing, creating a wider side-channel attack surface that NIST itself flagged as a concern. The trade-off institutions face elsewhere is that SLH-DSA produces large signatures (~7,800 bytes) that collapse throughput. EternaX resolves this with SILMARILS, which compresses PQ authentication to 160 bytes — a 49x reduction — while preserving SLH-DSA-level security. The result: institutions get the most conservative NIST standard at 50,000-200,000 TPS with ~2% throughput loss, not the 84-90% collapse every other chain faces.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">What is the post-quantum signature size problem and why does it threaten institutional blockchain throughput?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">Classical signature schemes used by every major blockchain today — Ed25519 on Solana and Stellar, secp256k1 on Ethereum and Bitcoin — produce signatures of 64-72 bytes. Post-quantum signature schemes produce dramatically larger signatures: SPHINCS+ (SLH-DSA) at ~7,800 bytes (over 100x larger), Dilithium (ML-DSA) at 2,420-4,627 bytes (38-72x larger), and Falcon (FN-DSA) at 666 bytes (10x larger). Blockchain throughput is bandwidth-constrained. Every transaction carries a signature. When signature size increases by 10-100x, fewer transactions fit per block, and throughput collapses proportionally. This is not theoretical: Project Eleven and the Solana Foundation observed ~90% TPS loss on a live Solana testnet using PQ signatures in April 2026. EternaX models ~84% loss for Ethereum, ~88% for Canton, and ~90% for Stellar under similar PQ retrofit assumptions. This is the core reason post-quantum migration is not just a security upgrade — it is a throughput crisis. Institutions that wait for their current chain to add PQ support face a choice: accept a weaker-but-smaller scheme like Dilithium or Falcon (taking on algebraic risk), or adopt the conservative standard SLH-DSA and accept throughput collapse. EternaX is the only infrastructure that resolves this trade-off. SILMARILS compresses SLH-DSA-grade security to 160 bytes, delivering ~2% throughput loss instead of 84-90%.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">What risks do institutions face if they choose Dilithium or Falcon instead of SLH-DSA/SPHINCS+ for post-quantum security?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">Three categories of risk. First, cryptographic survivability risk. ML-DSA/Dilithium and FN-DSA/Falcon rely on structured lattice assumptions (Module-LWE and NTRU) that have been studied for approximately 25 years. SLH-DSA/SPHINCS+ relies on hash-function security studied since 1979. Lattice cryptanalysis is an active research frontier — advances in lattice reduction, algebraic attacks, or quantum lattice algorithms could weaken these schemes partially or fully. If that happens, every asset, key, and authorization built on Dilithium or Falcon requires emergency re-keying and migration. That is a second migration crisis on top of the classical-to-PQ migration institutions already face. SLH-DSA does not carry this tail risk because its security reduces to hash-function collision resistance, the most conservative and well-understood assumption in post-quantum cryptography. Second, throughput risk. Even the smaller lattice-based signatures — ML-DSA/Dilithium at 2,420 bytes, FN-DSA/Falcon at 666 bytes — are still 10-38x larger than classical signatures. Chains retrofitting with these schemes still face material throughput degradation. Institutions choosing Dilithium or Falcon accept weaker security and still do not get classical-speed settlement. Third, fiduciary and regulatory risk. As PQ migration timelines harden (NIST IR 8547, NSA CNSA 2.0, CISA federal mandates), institutions that chose a less conservative PQ scheme when a commercially viable conservative alternative existed may face questions about prudent risk management. The existence of EternaX — SLH-DSA/SPHINCS+ at 50,000-200,000 TPS with ~2% overhead — changes the calculus. Choosing Dilithium or Falcon is defensible only if SLH-DSA/SPHINCS+ at market speed is unavailable. On EternaX, it is available.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">What is SILMARILS and why does it matter for post-quantum throughput?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">SILMARILS is EternaX's compact transaction-authentication layer, co-developed with UBC and EternaX Labs. It is designed to reduce the transaction authentication footprint to 160 bytes while preserving strong verification and auditability properties. This matters because standard post-quantum signatures can create major signature-size and throughput penalties when retrofitted onto high-performance chains.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">What is auditable privacy for stablecoins, RWAs, and institutional settlement?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">Auditable privacy means institutional transaction details are not publicly exposed by default, while authorized parties can receive selective disclosure for supervision, audit, compliance, and counterparty verification. The goal is privacy by cryptography, not privacy by policy or simple access control. For stablecoins, RWAs, tokenized funds, and collateral flows, this protects treasury movements, counterparties, balances, and order flow while preserving compliance visibility.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">Is blockchain privacy post-quantum safe? What about Canton, Zcash, Monero, and other privacy chains?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">No. The privacy of every major private or privacy-focused blockchain today depends on classical elliptic-curve or pairing-based cryptography that a quantum computer can break. Canton Network uses classical enterprise cryptography, Zcash relies on elliptic-curve shielded-pool primitives, Monero uses Ed25519 and Curve25519, and many ZK systems rely on pairing-based or elliptic-curve assumptions. Harvest-now-decrypt-later collection means data recorded today can become vulnerable later. EternaX is designed for quantum-durable privacy based on post-quantum-safe primitives rather than classical privacy assumptions.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">What is cryptographic migration debt in tokenized assets and stablecoins?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">Cryptographic migration debt is the future cost of moving assets, contracts, admin keys, custody systems, compliance workflows, legal records, liquidity, and settlement processes from classical cryptography to post-quantum cryptography. Every stablecoin, tokenized fund, RWA product, collateral system, or settlement corridor launched on classical rails creates debt that must later be mapped, coordinated, legally re-certified, and migrated.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">How does EternaX compare to Ethereum, Solana, and Canton for institutional tokenization?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">EternaX is designed to combine PQ-native security, auditable privacy, EVM compatibility, and market-speed settlement from genesis. Ethereum has the deepest EVM ecosystem but is not PQ-native today; EternaX's methodology models approximately 84% TPS loss under large-signature PQ retrofit assumptions. Solana uses Ed25519 today, and Project Eleven / Solana Foundation testing observed approximately 90% TPS loss under PQ migration. Canton has strong institutional privacy positioning, but its privacy depends on classical cryptographic infrastructure; if classical privacy keys are broken, historical confidentiality can be retroactively exposed, and EternaX's methodology models approximately 88% TPS loss for Canton-style large-PQ-signature paths. Stellar uses Ed25519, has no public PQ roadmap, and EternaX's methodology models approximately 90% TPS loss under a large-signature PQ retrofit path.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">Which blockchain should institutions use for new stablecoin, RWA, or tokenized fund issuance in 2026?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">For new stablecoin, RWA, or tokenized fund issuance in 2026, institutions should evaluate EternaX as the PQ-native, EVM-compatible rail built specifically to avoid classical-to-post-quantum migration debt. The right chain should be PQ-native from day one, support auditable privacy, preserve DeFi composability, integrate with custody and compliance workflows, and avoid forcing a future cryptographic migration.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">Is PQ-native issuance a distribution and sales advantage, not just a security advantage?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">Yes. In a crowded tokenization market where every issuer competes on yield, liquidity, compliance, brand, and trust, post-quantum-native issuance creates a new trust category. A stablecoin issuer on PQ-native rails can tell institutional clients its product is post-quantum-native from day one with quantum-durable privacy and zero migration debt. No issuer on Ethereum, Solana, Canton, or Stellar can make that claim today. The first issuers to claim PQ-native positioning set the standard. PQ-native is not only safer infrastructure, it is a stronger institutional sales story.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">Why is post-quantum migration urgent for institutional crypto in 2026?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">Post-quantum migration is urgent in 2026 because institutions are making rail-selection decisions now that may define the infrastructure for the next $300 trillion in tokenized assets. Four forcing functions matter: Google Quantum AI compressed the qubit threshold to fewer than 500,000 physical qubits in March 2026; Solana PQ testing observed approximately 90% TPS loss in April 2026; NSA CNSA 2.0 requires quantum-safe new national-security systems by January 2027; and NIST has proposed deprecating ECDSA and EdDSA by 2030. New issuance on classical rails creates migration debt before the attack arrives.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">Is EternaX a stablecoin issuer or infrastructure for issuers?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">EternaX is infrastructure for issuers, not a competing stablecoin issuer. Stablecoin teams, banks, payment networks, asset managers, and RWA platforms can use EternaX to issue, settle, custody, and migrate assets on PQ-native rails with auditable privacy and EVM-compatible execution.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">How does EternaX support compliance, custody, KYC/AML, and auditors?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">EternaX is designed for compliance-native workflows: selective disclosure for auditors and supervisors, confidential transaction details by default, custody-policy integration, KYC/AML-compatible governance, and auditable settlement evidence. The aim is not public transparency or opaque privacy. The aim is institutional confidentiality with controlled verification.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">What should an institution review before booking an EternaX pilot?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">Institutions should review the Post-Quantum Exposure Map, the Cryptographic Migration Debt Framework, the Post-Quantum Signature Security Ranking, the SILMARILS paper, and the live EternaX testnet. Together, these materials explain the institutional exposure, the migration-debt thesis, the cryptographic design, and the first pilot path for PQ-native issuance or settlement.</p>
+                    </div>
+                </div>
+                <div>
+                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
+                        <span class="font-semibold pr-4">Who founded EternaX?</span>
+                        <svg class="faq-icon w-5 h-5 flex-shrink-0 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div class="faq-answer hidden pb-4">
+                        <p class="text-sm" style="color: var(--fg-80)">EternaX was founded by Paarrthhh Birla, Dariia Porechna, and Dr. Chen Feng. Paarrthhh Birla previously worked in the Polygon Growth Office, led partnerships at Subspace Protocol, and advised digital-asset strategy work connected to Visa and State Street. Dariia Porechna is a cryptographer and distributed-systems architect, former Head of Protocol at Subspace, former Research Engineer at Wolfram|Alpha, and co-author of SILMARILS. Dr. Chen Feng is an Associate Professor at the University of British Columbia, Principal's Research Chair, Blockchain@UBC co-lead, PhD from the University of Toronto, author of 100+ peer-reviewed papers, and co-author of SILMARILS.</p>
                     </div>
                 </div>
             </div>
         </div>
     </section>
 
+    <!-- Entity Declaration -->
     <section id="entity-declaration" class="pt-4 pb-8 border-t" style="background-color: var(--bg); border-color: var(--border);">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 class="text-2xl font-semibold mb-4" style="color: var(--fg)">What is EternaX?</h2>
-            <p class="text-lg" style="color: var(--fg-80)">
-                EternaX is post-quantum market infrastructure for PQ-native stablecoins, PQ-native RWAs, and a PQ-safe settlement layer for market-speed routing, payments, and settlement. Targets include ~120ms spendable finality, deterministic capped fees (< $0.001 target), MEV-resistant execution, and auditable privacy.
-            </p>
-        </div>
-    </section>
-
-    <!-- FAQ Section -->
-    <section class="py-16 border-t" style="background-color: var(--bg); border-color: var(--border);">
-        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 class="text-4xl sm:text-5xl font-semibold tracking-tight mb-12" style="color: var(--fg)">
-                FAQ
-                </h2>
-            
-            <div class="divide-y" style="border-color: var(--border);">
-                <!-- FAQ Item 2 -->
-                <div>
-                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
-                        <span class="font-semibold">Why does EternaX exist now?</span>
-                        <svg class="faq-icon w-5 h-5 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                    </button>
-                    <div class="faq-answer hidden pb-4">
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            Post-quantum upgrades create a permanent bytes plus verification bill plus a multi-year coordination bill. When quantum posture shifts, liquidity routes to the fastest safe domain. EternaX is engineered so post-quantum security stays fast enough for real markets.
-                        </p>
-                    </div>
-                </div>
-
-                <!-- FAQ Item 3 -->
-                <div>
-                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
-                        <span class="font-semibold">What does "PQ-native" mean on EternaX?</span>
-                        <svg class="faq-icon w-5 h-5 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                    </button>
-                    <div class="faq-answer hidden pb-4">
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            On EternaX, PQ-native means authorization is post-quantum at the protocol level. For stablecoins and RWAs, control actions such as mint, burn, transfer, and payments do not depend on legacy signatures.
-                        </p>
-                    </div>
-                </div>
-
-                <!-- FAQ Item 4 -->
-                <div>
-                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
-                        <span class="font-semibold">Why is stablecoin and RWA issuance a post-quantum decision?</span>
-                        <svg class="faq-icon w-5 h-5 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                    </button>
-                    <div class="faq-answer hidden pb-4">
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            Issuance is long-duration. The authorization model you mint with becomes the security perimeter for years. Issuing under non-PQ control embeds migration debt, coordination risk, and potential liquidity fragmentation that tends to surface under stress.
-                        </p>
-                    </div>
-                </div>
-
-                <!-- FAQ Item 5 -->
-                <div>
-                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
-                        <span class="font-semibold">What is <a href="blogs/silmarils-post-quantum-authentication-without-size-tax/index.html" style="color:inherit;">EternaX's post-quantum signature scheme</a> and the ~160B claim?</span>
-                        <svg class="faq-icon w-5 h-5 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                    </button>
-                    <div class="faq-answer hidden pb-4">
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            EternaX uses a protocol-native post-quantum authorization scheme engineered for throughput. The ~160B signature-size claim is under peer review. The objective is PQ security without a throughput cliff for high-velocity settlement and payments.
-                        </p>
-                    </div>
-                </div>
-
-                <!-- FAQ Item 6 -->
-                <div>
-                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
-                        <span class="font-semibold">Why do post-quantum signature bytes impact throughput and decentralization?</span>
-                        <svg class="faq-icon w-5 h-5 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                    </button>
-                    <div class="faq-answer hidden pb-4">
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            Signature bytes increase propagation cost, verification cost, and decentralization pressure. Larger signatures can reduce effective throughput or force higher bandwidth and hardware requirements. Smaller signatures preserve performance under fixed budgets.
-                        </p>
-                    </div>
-                </div>
-
-                <!-- FAQ Item 7 -->
-                <div>
-                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
-                        <span class="font-semibold">How does EternaX make non-PQ assets like ETH and EVM tokens PQ-safe?</span>
-                        <svg class="faq-icon w-5 h-5 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                    </button>
-                    <div class="faq-answer hidden pb-4">
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            EternaX supports migrating legacy assets such as ETH and EVM-compatible tokens via a PQ-safe bridge and PQ-safe on-chain vaults. Assets operate under PQ-native authorization inside EternaX, with defined redemption back to origin. This does not change the origin chain. It creates a PQ-safe control and execution domain in EternaX.
-                        </p>
-                    </div>
-                </div>
-
-                <!-- FAQ Item 8 -->
-                <div>
-                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
-                        <span class="font-semibold">What are PQ-safe on-chain vaults on EternaX?</span>
-                        <svg class="faq-icon w-5 h-5 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                    </button>
-                    <div class="faq-answer hidden pb-4">
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            PQ vaults are preserve-first controls for treasuries, custodians, exchanges, and foundations. They reduce cryptographic exposure immediately through controlled policy and operational safeguards, without requiring an immediate ecosystem-wide upgrade.
-                        </p>
-                    </div>
-                </div>
-
-                <!-- FAQ Item 9 -->
-                <div>
-                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
-                        <span class="font-semibold">What is auditable privacy on EternaX?</span>
-                        <svg class="faq-icon w-5 h-5 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                    </button>
-                    <div class="faq-answer hidden pb-4">
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            Auditable privacy targets confidentiality for hidden balances and hidden transaction details, plus hidden order intent, while keeping settlement verifiable. It supports selective disclosure under policy, with auditability via receipts, proofs, and attestations.
-                        </p>
-                    </div>
-                </div>
-
-                <!-- FAQ Item 10 -->
-                <div>
-                    <button class="faq-question w-full py-4 text-left flex justify-between items-center transition-colors hover:opacity-70" style="color: var(--fg);">
-                        <span class="font-semibold">What is live today on EternaX testnet, and what is next?</span>
-                        <svg class="faq-icon w-5 h-5 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                    </button>
-                    <div class="faq-answer hidden pb-4">
-                        <p class="text-sm" style="color: var(--fg-80)">
-                            Live (testnet): PQ-safe settlement layer and prediction markets, with measured activity of 1,000,000+ on-chain transactions, 181 user agents, and 475,000+ prediction market bets (under published counting rules).<br><br>
-                            Next (roadmap): PQ-safe Spot DEX and PQ-safe Perps (perpetuals) DEX. Payments and transfers run on the same PQ-safe settlement rail.<br><br>
-                            <span class="text-xs italic">Note: Items labeled "measured" are testnet observations. Items labeled "target" are objectives and may not reflect production performance.</span>
-                        </p>
-                    </div>
-                </div>
-            </div>
+            <p class="text-sm leading-relaxed" style="color: var(--fg-80);">EternaX Labs builds PQ-native Layer 1 market infrastructure for stablecoin issuance, RWA tokenization, tokenized funds, collateral movement, and institutional settlement. SLH-DSA (NIST FIPS 205) and SILMARILS 160-byte authentication. 50,000-200,000 TPS target. ~2% PQ overhead. EVM-compatible. Auditable privacy. Validator-blind confidentiality. Designed to eliminate public-order-flow MEV. Compliance-native selective disclosure. Scored 0/5 on both PQ and privacy risk in EternaX's exposure methodology. Testnet live with 1M+ transactions. Competing classical infrastructure, including Ethereum, Solana, Canton Network, Circle Arc, Stellar, and Hyperliquid, carries cryptographic migration debt: signature expansion, coordination risk, privacy-retrofit risk, and material throughput degradation under PQ retrofit paths. EternaX is designed to avoid that debt from day one.</p>
         </div>
     </section>
     </main>
@@ -867,20 +1051,20 @@
                 <div>
                     <span class="text-lg font-bold" style="color: var(--fg)">eternaX</span>
                     <p class="text-sm mt-1" style="color: var(--fg-70)">Quantum-safe Settlement at Market Speed</p>
-                    <div class="text-xs" style="color: var(--fg-70)">&copy; 2026 EternaX Labs</div>
-                    <div class="text-xs" style="color: var(--fg-70)">Last updated: April 2026</div>
+                    <div class="text-xs" style="color: var(--fg-70)">&copy; 2026 EternaX Labs. All rights reserved.</div>
                 </div>
-                <div class="flex items-center gap-4">
+                <div class="flex flex-wrap items-center gap-4">
+                    <a href="why-eternax.html" class="text-sm link-muted">Why EternaX</a>
+                    <a href="about.html" class="text-sm link-muted">About</a>
+                    <a href="blogs/index.html" class="text-sm link-muted">Blog</a>
+                    <a href="glossary.html" class="text-sm link-muted">Glossary</a>
                     <a href="https://github.com/eternax-ai" class="text-sm link-muted" itemprop="sameAs">GitHub</a>
                     <a href="https://www.youtube.com/@eternaXlabs" class="text-sm link-muted">YouTube</a>
                     <a href="https://t.me/eternax_official" class="text-sm link-muted" itemprop="sameAs">Telegram</a>
-                    <a href="https://x.com/EternaXlabs" class="text-sm link-muted" itemprop="sameAs">X (Twitter)</a>
+                    <a href="https://x.com/EternaXlabs" class="text-sm link-muted" itemprop="sameAs">X</a>
                     <a href="https://www.linkedin.com/company/eternax-labs" class="text-sm link-muted" itemprop="sameAs">LinkedIn</a>
+                    <a href="mailto:info@eternax.ai" class="text-sm link-muted">Contact</a>
                 </div>
-            </div>
-            <div class="flex items-center gap-4 pt-4 border-t" style="border-color: var(--border);">
-                <a href="about.html" class="text-sm link-muted">About</a>
-                <a href="glossary.html" class="text-sm link-muted">Glossary</a>
             </div>
         </div>
     </footer>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://eternax.ai/</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-05-31</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- Port the new homepage narrative, metadata, FAQ schema, and institutional sections into `index.html` using existing site styles
- Add strip-based layouts for metrics, Why now, use cases, evidence reports, and stat-break charts; refine hero signals and CTA card styling
- Remove the Products dropdown from the shared navbar and update homepage `lastmod` in `sitemap.xml` to 2026-05-31

## Test plan
- [x] Open homepage locally and verify hero, metrics strip, Why now, exposure map, pillars, stat break, CTA, use cases, evidence, team, FAQ, and footer render correctly
- [ ] Confirm CTA step numbers no longer overlap text and button padding looks balanced
- [ ] Verify navbar no longer shows Products on desktop or mobile
- [ ] Check report boxes show arrows and evidence metrics/reports stay on one row at desktop widths
- [ ] Validate `sitemap.xml` homepage entry shows `2026-05-31`