### PR TITLE
Add Post-Quantum MPC Custody Crisis institutional report

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -11,7 +11,11 @@
                     </span>
                     <div class="nav-products-dropdown absolute left-0 top-full pt-1">
                         <div class="glass-effect rounded-lg py-2 min-w-[340px] shadow-lg" style="border: 1px solid var(--border)">
-                            <a href="{{ '/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html' | relative_url }}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
+                            <a href="{{ '/post_quantum_mpc_custody_crisis_hash_based_sphincs_institutional.html' | relative_url }}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5 rounded-t-lg" style="color: var(--fg); border-color: var(--border)">
+                                <span class="font-semibold text-sm block">Post-Quantum MPC Custody Crisis 2026</span>
+                                <span class="text-xs block mt-0.5" style="color: var(--fg-80)">12 June 2026 · 15 institutional MPC providers, $10T+ in assets, zero post-quantum safe custody.</span>
+                            </a>
+                            <a href="{{ '/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html' | relative_url }}" class="block px-4 py-3.5 hover:opacity-90 transition-colors border-b hover:bg-black/5" style="color: var(--fg); border-color: var(--border)">
                                 <span class="font-semibold text-sm block">Post-Quantum Exposure Map 2026</span>
                                 <span class="text-xs block mt-0.5" style="color: var(--fg-80)">May 2026 · Institutional exposure map for tokenized assets, stablecoins, RWAs, collateral, and privacy.</span>
                             </a>
@@ -53,6 +57,7 @@
             <div class="mt-2 space-y-3 border-t pt-4" style="border-color: var(--border)">
                 <a href="{{ '/why-eternax.html' | relative_url }}" class="block px-1 hover:opacity-70 transition-colors" style="color: var(--fg-70)">Why EternaX</a>
                 <span class="block px-1 text-sm font-semibold" style="color: var(--fg-70)">Quantum Risk Reports</span>
+                <a href="{{ '/post_quantum_mpc_custody_crisis_hash_based_sphincs_institutional.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum MPC Custody Crisis 2026 <span class="text-xs opacity-60">12 Jun 2026</span></a>
                 <a href="{{ '/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Post-Quantum Exposure Map 2026 <span class="text-xs opacity-60">May 2026</span></a>
                 <a href="{{ '/post-quantum-signature-security-ranking-2026.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Signature Security Ranking 2026 <span class="text-xs opacity-60">May 2026</span></a>
                 <a href="{{ '/post-quantum-cryptography-risk-framework-for-institutions.html' | relative_url }}" class="block px-1 pl-4 hover:opacity-70 transition-colors text-sm" style="color: var(--fg-70)">Cryptographic Migration Debt Framework <span class="text-xs opacity-60">Apr 2026</span></a>

--- a/post_quantum_mpc_custody_crisis_hash_based_sphincs_institutional.html
+++ b/post_quantum_mpc_custody_crisis_hash_based_sphincs_institutional.html
@@ -1,0 +1,1929 @@
+---
+---
+<!DOCTYPE html>
+
+<html lang="en" prefix="og: https://ogp.me/ns#">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>The Post-Quantum Institutional MPC Custody Crisis 2026: Hash-Based Signatures (SPHINCS+) Break MPC Custody | 15 Providers, $10T, Zero PQ-Safe | EternaX Labs</title>
+<meta content="15 institutional MPC custody providers protect $10T+ in digital assets, but none are post-quantum safe. Why hash-based PQ signatures (SPHINCS+ / SLH-DSA) break MPC custody and what institutions must do before NIST 2030." name="description"/>
+<meta content="quantum-safe settlement, post-quantum cryptography, PQ-native assets, post-quantum market infrastructure, quantum-resistant blockchain, MPC custody post-quantum, SPHINCS+ MPC impossibility, institutional custody quantum risk, post-quantum custody providers, digital asset custody migration, MPC vs HSM post-quantum, threshold SPHINCS+ impossible, NIST FIPS 205 custody, PQ-safe vaults, RWA tokenization, auditable privacy" name="keywords"/>
+<meta content="EternaX Labs" name="author"/>
+<meta content="index, follow, max-snippet:-1, max-image-preview:large" name="robots"/>
+<meta content="index, follow" name="googlebot"/>
+<meta content="index, follow" name="bingbot"/>
+<meta content="#e2e2e2" name="theme-color"/>
+<meta content="light" name="color-scheme"/>
+<meta content="telephone=no" name="format-detection"/>
+<meta content="global" name="distribution"/>
+<meta content="general" name="rating"/>
+<link href="https://eternax.ai/post-quantum-mpc-custody-crisis-hash-based-sphincs-institutional-risk-map-2026.html" rel="canonical"/>
+<meta content="article" property="og:type"/>
+<meta content="https://eternax.ai/assets/preview.png" property="og:image"/>
+<meta content="1200" property="og:image:width"/>
+<meta content="630" property="og:image:height"/>
+<meta content="EternaX - Post-Quantum Market Infrastructure" property="og:image:alt"/>
+<meta content="https://eternax.ai/post-quantum-mpc-custody-crisis-hash-based-sphincs-institutional-risk-map-2026.html" property="og:url"/>
+<meta content="Post-Quantum Institutional Custody Crisis 2026: Hash-Based Signatures Break MPC | 15 Providers, $10T at Risk" property="og:title"/>
+<meta content="Institutional risk map of MPC custody under hash-based post-quantum migration. Hash-based PQ signatures (SPHINCS+ / SLH-DSA, NIST FIPS 205) are mathematically incompatible with MPC. One architecture survives." property="og:description"/>
+<meta content="EternaX Labs" property="og:site_name"/>
+<meta content="en_US" property="og:locale"/>
+<meta content="https://eternax.ai" property="article:publisher"/>
+<meta content="2026-06-09" property="article:published_time"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="https://eternax.ai/assets/preview.png" name="twitter:image"/>
+<meta content="EternaX - Post-Quantum Market Infrastructure" name="twitter:image:alt"/>
+<meta content="https://eternax.ai/post-quantum-mpc-custody-crisis-hash-based-sphincs-institutional-risk-map-2026.html" name="twitter:url"/>
+<meta content="Post-Quantum Institutional Custody Crisis 2026: Hash-Based Signatures Break MPC | 15 Providers, $10T at Risk" name="twitter:title"/>
+<meta content="Institutional risk map of MPC custody under hash-based post-quantum migration. Hash-based PQ signatures (SPHINCS+ / SLH-DSA) are mathematically incompatible with MPC. One architecture survives." name="twitter:description"/>
+<meta content="@EternaXlabs" name="twitter:site"/>
+<meta content="@EternaXlabs" name="twitter:creator"/>
+<meta content="human-authored" name="ai-content-declaration"/>
+<link rel="icon" type="image/svg+xml" href="./assets/eternax-icon.svg">
+<link rel="icon" type="image/png" href="./assets/eternax-icon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com" rel="dns-prefetch"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link rel="stylesheet" href="./styles/tailwind.generated.css">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;1,400&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400;1,500&family=IBM+Plex+Serif:ital,wght@0,400;0,600;1,400&family=Inter:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400;1,500;1,600&display=swap" rel="stylesheet">
+<script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "EternaX Labs",
+  "alternateName": "eternaX",
+  "url": "https://eternax.ai",
+  "description": "Post-quantum market infrastructure for stablecoin issuance, RWA tokenization, and institutional settlement.",
+  "foundingDate": "2024",
+  "industry": "Blockchain Infrastructure, Post-Quantum Cryptography",
+  "sameAs": [
+    "https://x.com/eternaXLabs",
+    "https://github.com/eternax-ai",
+    "https://www.youtube.com/@eternaXlabs",
+    "https://farcaster.xyz/eternax",
+    "https://www.linkedin.com/company/eternax-labs"
+  ],
+  "founder": [
+    {
+      "@type": "Person",
+      "name": "Dariia Porechna",
+      "jobTitle": "Co-Founder",
+      "url": "https://www.linkedin.com/in/dariia-porechna",
+      "image": "https://eternax.ai/assets/dariia.png",
+      "description": "Cryptographer and distributed systems architect; Head of Protocol, Subspace; Research Engineer, Wolfram|Alpha. Co-author, SILMARILS.",
+      "sameAs": [
+        "https://www.linkedin.com/in/dariia-porechna",
+        "https://x.com/FutureDies"
+      ]
+    },
+    {
+      "@type": "Person",
+      "name": "Paarrthhh Birla",
+      "jobTitle": "Co-Founder",
+      "url": "https://www.linkedin.com/in/paarrthhh-birla-b3607bb4/",
+      "image": "https://eternax.ai/assets/parthh.png",
+      "description": "Ex-Polygon (VP Growth Office); Head of Partnerships, Subspace Protocol; Digital assets strategy at EYP, Advised Visa and State Street; MBA, CPA.",
+      "sameAs": [
+        "https://www.linkedin.com/in/paarrthhh-birla-b3607bb4/",
+        "https://x.com/paarrthhbirla"
+      ]
+    },
+    {
+      "@type": "Person",
+      "name": "Dr. Chen Feng",
+      "jobTitle": "Chief Scientist",
+      "url": "https://www.linkedin.com/in/chen-feng-75272a37",
+      "image": "https://eternax.ai/assets/chen.png",
+      "description": "Assoc. Prof. at University of British Columbia; PhD (Toronto); 100+ peer-reviewed papers; Quantum communications, blockchain, TEE privacy. Co-author, SILMARILS.",
+      "sameAs": [
+        "https://www.linkedin.com/in/chen-feng-75272a37",
+        "https://scholar.google.com/citations?user=D8b0l-EAAAAJ"
+      ]
+    }
+  ],
+  "knowsAbout": [
+    "Post-quantum cryptography",
+    "Institutional digital asset custody",
+    "Stablecoin issuance",
+    "RWA tokenization",
+    "Blockchain infrastructure",
+    "MPC custody",
+    "SPHINCS+",
+    "SLH-DSA"
+  ]
+}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "url": "https://eternax.ai",
+  "name": "EternaX Labs",
+  "description": "Post-quantum market infrastructure for stablecoin issuance, RWA tokenization, and institutional settlement.",
+  "publisher": {"@type": "Organization", "name": "EternaX Labs"},
+  "inLanguage": "en"
+}
+</script>
+<script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "ScholarlyArticle",
+  "headline": "The Post-Quantum Institutional MPC Custody Crisis 2026: Why Hash-Based PQ Signatures (SPHINCS+ / SLH-DSA) Are Incompatible with MPC Custody",
+  "description": "Institutional risk map of MPC custody under hash-based post-quantum migration. 15 providers reviewed across $10T+ in assets. Hash-based PQ signatures (SPHINCS+ / SLH-DSA, NIST FIPS 205) are mathematically incompatible with MPC. One architecture survives.",
+  "author": {
+    "@type": "Organization",
+    "name": "EternaX Labs",
+    "url": "https://eternax.ai"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "EternaX Labs"
+  },
+  "datePublished": "2026-06-09",
+  "url": "https://eternax.ai/post-quantum-mpc-custody-crisis-hash-based-sphincs-institutional-risk-map-2026.html",
+  "inLanguage": "en",
+  "about": [
+    "Post-Quantum Cryptography",
+    "Hash-Based Post-Quantum Signatures",
+    "MPC Custody",
+    "Institutional Digital Asset Security",
+    "SPHINCS+ / SLH-DSA",
+    "NIST FIPS 205"
+  ],
+  "citation": [
+    "https://eprint.iacr.org/2015/1075",
+    "https://www.nist.gov/news-events/news/2024/08/nist-releases-first-3-finalized-post-quantum-encryption-standards",
+    "https://pq.ethereum.org/",
+    "https://ethresear.ch/t/how-to-hard-fork-to-save-most-users-funds-in-a-quantum-emergency/18901",
+    "https://arxiv.org/abs/1804.08714",
+    "https://arxiv.org/abs/2605.03230",
+    "https://eternax.ai/post-quantum-cryptography-risk-framework-for-institutions.html",
+    "https://eternax.ai/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html",
+    "https://www.trmlabs.com/resources/blog/trms-ari-redbord-testifies-before-the-house-committee-on-financial-services-subcommittee-on-national-security",
+    "https://www.blackrock.com/corporate/literature/article-reprint/larry-fink-rob-goldstein-economist-op-ed-tokenization.pdf",
+    "https://www.prnewswire.com/news-releases/silence-laboratories-launches-first-quantum-safe-vault-for-digital-asset-custody-302755724.html",
+    "https://www.nextgov.com/emerging-tech/2023/08/new-post-quantum-cryptography-guidance-offers-first-steps-toward-migration/389595/",
+    "https://industrialcyber.co/cisa/cisa-nsa-nist-factsheet-addresses-migration-to-post-quantum-cryptography-ahead-of-standards-rollout/"
+  ],
+  "dateModified": "2026-06-10"
+}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://eternax.ai"},
+    {"@type": "ListItem", "position": 2, "name": "Research", "item": "https://eternax.ai/research"},
+    {"@type": "ListItem", "position": 3, "name": "Post-Quantum Institutional MPC Custody Crisis 2026", "item": "https://eternax.ai/post-quantum-mpc-custody-crisis-hash-based-sphincs-institutional-risk-map-2026.html"}
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is post-quantum custody?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Post-quantum custody is digital asset custody infrastructure that remains secure after a cryptographically relevant quantum computer can break today’s classical public-key signatures. The issue is not only wallet security; it is the full custody and settlement stack: ECDSA, Ed25519, Schnorr, key recovery, policy engines, backup encryption, MPC workflows, HSM boundaries, and chain-level signature verification. Institutions using Fireblocks, Copper, BitGo, Anchorage Digital, Cobo, Dfns, Safeheron, Fordefi (Paxos), or similar providers still rely on classical signatures on the underlying chains."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why does post-quantum custody matter for institutions?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Post-quantum custody matters because institutional digital assets are controlled by signatures, not by branding, regulation, or custody policy alone. A quantum adversary that can recover private keys from exposed public keys can bypass the operational controls around those keys. This affects custody wallets, mint keys, bridge validators, tokenized fund administrators, stablecoin issuers, staking operators, treasury systems, and settlement rails. The risk is structural because every major public chain still verifies classical signatures."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is MPC custody post-quantum safe?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. MPC custody is not post-quantum safe if the final signature verified by the blockchain is still ECDSA, Ed25519, or Schnorr. MPC distributes signing authority across multiple parties, which improves operational security against theft, insiders, and device compromise. But MPC does not change the chain-visible signature scheme. A quantum adversary attacks the public-key signature layer that consensus verifies, not the internal MPC ceremony used to produce the signature."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does MPC protect against Shor’s algorithm?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. MPC does not protect ECDSA, Ed25519, or Schnorr signatures from Shor’s algorithm. Shor’s algorithm attacks the mathematical hardness assumptions behind elliptic-curve and RSA cryptography. MPC can split control of a private key across parties, but once a public key is exposed on-chain, the underlying classical signature scheme remains vulnerable. This is why MPC custody and post-quantum custody are not the same thing."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are Fireblocks, Copper, BitGo, Cobo, Dfns, Safeheron, and Fordefi post-quantum safe?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No reviewed institutional MPC custody provider is post-quantum safe today. Fireblocks, Copper, BitGo, Anchorage Digital, Ripple Custody, Cobo, Dfns, Safeheron, Fordefi (Paxos), Zodia Custody, Qredo, and similar platforms may offer strong operational controls, but the assets they custody ultimately settle on chains using classical signatures. Unless the underlying chain supports post-quantum verification and the custody architecture can operate with that verification model, the custody stack remains exposed to quantum key recovery."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can MPC threshold-compute SPHINCS+ signatures?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Threshold SPHINCS+ is not commercially practical for institutional MPC custody because hash-based signatures lack the algebraic structure MPC needs for efficient distributed signing. SPHINCS+ signing requires thousands of hash computations, and threshold-computing those operations across multiple institutional parties creates extreme communication and round-complexity overhead. This is a structural cryptographic barrier, not a simple implementation gap or vendor roadmap issue."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why is SPHINCS+ preferred for conservative institutional post-quantum security?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "SPHINCS+, standardized by NIST as SLH-DSA in FIPS 205, is preferred by conservative institutions because it is hash-based. Its security relies on hash-function assumptions that have been studied for decades, rather than newer lattice assumptions. That makes SPHINCS+ attractive for critical infrastructure, long-duration assets, settlement systems, tokenized funds, and regulated financial infrastructure where robustness matters more than elegance. The problem is that SPHINCS+ is structurally incompatible with conventional MPC custody."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between MPC and HSM custody for post-quantum migration?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "HSM custody can support post-quantum signature standards such as SPHINCS+ inside a protected hardware boundary, while conventional MPC custody cannot efficiently threshold-compute hash-based SPHINCS+ signatures. The tradeoff is severe: HSMs offer post-quantum algorithm support but concentrate trust in hardware boundaries; MPC distributes trust but struggles with the most conservative hash-based PQ signatures. EternaX resolves this by separating MPC-compatible custody control from post-quantum authentication at the chain level."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the NIST 2030 and 2035 timeline for classical signatures?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The relevant NIST migration timeline signals that classical public-key schemes such as ECDSA, EdDSA, RSA, and related signature systems should be phased out of sensitive systems over the next decade. For digital assets, that matters because Ethereum, Bitcoin, Solana, Polygon, Avalanche, Arbitrum, BNB Chain, Stellar, and most custody systems still depend on classical signatures. Institutions should not wait until the deadline year; custody migrations require years of vendor review, chain support, testing, audits, governance, and counterparty acceptance."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which major blockchains are post-quantum safe today?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No major public blockchain is post-quantum safe in production today. Ethereum, Bitcoin, Solana, Polygon, Avalanche, Arbitrum, Optimism, BNB Chain, Stellar, Aptos, Sui, Canton, and similar networks still rely on classical signature verification in their production settlement flows. Some ecosystems are researching post-quantum migration, but research direction is not production protection. Assets remain exposed until the chain, account model, wallet stack, custody layer, and migration path are all post-quantum-ready."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can Ethereum, Bitcoin, or Solana migrate to SPHINCS+ without breaking MPC custody?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Not cleanly. If a chain simply replaces ECDSA or Ed25519 with SPHINCS+, it may improve post-quantum signature security but can break compatibility with conventional MPC custody. That is because SPHINCS+ is hash-based and not efficiently threshold-computable under standard MPC models. A serious migration must solve both problems together: post-quantum chain verification and institutional distributed custody. Treating them separately creates a new custody bottleneck."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between post-quantum custody and post-quantum settlement?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Post-quantum custody protects the systems that authorize asset movement; post-quantum settlement protects the chain that validates and finalizes asset movement. Institutions need both. A custody provider can harden devices, approvals, policies, and key storage, but if the blockchain still accepts classical signatures, the final settlement layer remains quantum-exposed. EternaX focuses on post-quantum settlement infrastructure so custody providers can operate on a rail designed for quantum-durable transaction validity from genesis."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is custody control-plane risk in a post-quantum world?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Custody control-plane risk is the risk that the systems controlling authorization are compromised, even if the asset contract itself is not hacked. Today, attackers target laptops, admin consoles, policy engines, signer devices, backups, bridges, validator keys, and multisig quorums. In a post-quantum world, the attacker may not need theft, phishing, malware, or social engineering. If public keys are exposed and signatures are classical, quantum key recovery can convert control-plane risk into mathematical key compromise."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How much crypto has been stolen through private key and signing-control compromise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Billions of dollars have been lost through private key compromise, signer compromise, phishing, malware, multisig failures, bridge validator compromise, and admin-key misuse. The institutional lesson is direct: the control plane of crypto is the signing layer. Smart-contract audits do not protect assets if the keys that authorize movement are compromised. A quantum attacker turns this same pattern into an algorithmic attack by recovering keys from vulnerable public-key cryptography."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are tokenized funds, stablecoins, and RWAs exposed to post-quantum custody risk?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Tokenized funds, stablecoins, and real-world assets are exposed if their minting, redemption, transfer, admin, bridge, or settlement workflows depend on classical signatures. This includes assets issued on Ethereum, Solana, Polygon, Avalanche, Stellar, Canton, and other classically signed networks. The risk is not limited to asset holders; it affects issuers, transfer agents, custodians, market makers, settlement venues, auditors, administrators, and distribution partners."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can lattice-based post-quantum signatures solve MPC custody?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Lattice-based post-quantum signatures may be more MPC-compatible than SPHINCS+, but they are not the conservative institutional default. Threshold ML-DSA and related approaches remain newer, more complex, and less production-validated than classical MPC custody. They also rely on lattice assumptions rather than hash-based assumptions. For institutions that want conservative, hash-based post-quantum assurance, lattice-based MPC is not equivalent to SPHINCS+ custody support."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can existing blockchains retrofit post-quantum MPC custody support?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Existing blockchains can research post-quantum signatures, but retrofitting post-quantum MPC custody is much harder than adding a new signature opcode. A real migration requires new account models, wallet support, custody integrations, validator/client changes, transaction-size management, migration tooling, and governance acceptance. If the chain adopts SPHINCS+ as a simple replacement signature, it may create a custody architecture where conventional MPC cannot efficiently operate."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does EternaX support MPC custody with SPHINCS+ compliance?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EternaX separates custody authorization from post-quantum authentication at the chain level. The custody side can remain compatible with distributed authorization models used by institutional MPC providers, while the chain enforces post-quantum transaction validity through a SPHINCS+-aligned authentication layer. This avoids forcing institutions into a false choice between distributed custody and conservative hash-based post-quantum security. The design is native to the settlement rail, not bolted on after launch."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is EternaX’s performance under post-quantum cryptography?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EternaX is designed to keep post-quantum security compatible with institutional market speed. The architecture targets high-throughput settlement while keeping post-quantum authentication overhead structurally lower than simply placing full SPHINCS+ signatures on every transaction. The key claim is not that post-quantum cryptography is free; it is that PQ performance must be engineered at the settlement-layer architecture level, not retrofitted into chains designed around classical signatures."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should institutions ask their MPC custody provider about post-quantum risk?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Institutions should ask their MPC provider for a written post-quantum roadmap, supported signature schemes, chain migration assumptions, control-plane protections, HSM strategy, lattice-risk posture, SPHINCS+ support, account-migration plan, and expected customer impact before 2030. The key question is not “Do you use MPC?” The key question is “How will this custody stack authorize and settle assets when classical signatures are no longer acceptable?”"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should tokenized asset issuers, stablecoin issuers, and funds do now?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Issuers should map every signing authority that can move, mint, burn, freeze, upgrade, bridge, redeem, or administer assets. They should classify which keys are classical, which chains expose public keys, which custody providers control workflows, and which assets have no documented post-quantum migration path. New tokenized assets should avoid inheriting quantum debt by default. For long-duration institutional products, post-quantum settlement should become a distribution and risk-management requirement, not a future compliance footnote."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is post-quantum custody only a security problem?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Post-quantum custody is a market-infrastructure problem. The institutions that solve it first can offer safer tokenized funds, stronger stablecoin issuance, more credible collateral rails, and better long-duration settlement guarantees. The institutions that delay may face stranded custody workflows, expensive migrations, counterparty pushback, and weaker distribution in regulated tokenized markets. Post-quantum readiness is not only defensive security; it is a trust and distribution edge."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can my existing custody provider offer PQ-safe custody on EternaX?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EternaX is the only chain where existing MPC custody infrastructure remains functional under hash-based post-quantum migration. Your custody provider runs their distributed authorization quorum exactly as they do today. The chain handles SPHINCS+ (hash-based, NIST FIPS 205) verification at the protocol level. No threshold computation of hash-based signatures is required. Your provider keeps their MPC, their licenses, their policy engine, and your client relationship. You get hash-based PQ-safe custody without switching providers."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EternaX compete with MPC custody providers?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. EternaX is a settlement rail, not a custodian. Custody providers keep their clients, their licenses, their MPC infrastructure, and their operating models. EternaX makes their custody hash-based PQ-safe. The chain provides the architecture where the custody provider's MPC authorization output composes with SPHINCS+ verification at the protocol level. This is analogous to how Ethereum provides the settlement layer and Fireblocks provides the custody layer, except that on EternaX, the custody provider can offer hash-based post-quantum compliance that is mathematically impossible on any other chain."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is EternaX?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EternaX is post-quantum market infrastructure for stablecoin issuance, tokenized real-world assets, institutional custody workflows, and settlement. It is designed as a PQ-native Layer 1 where post-quantum authentication, institutional performance, and custody-provider compatibility are engineered into the settlement rail from genesis. The core thesis is simple: institutions should not have to choose between MPC-grade operational control and hash-based post-quantum security."
+      }
+    }
+  ]
+}
+</script>
+<style>
+/* ════════════════════════════════════════════════
+   ETERNAX PREMIUM LIGHT INSTITUTIONAL PALETTE
+   EternaX Research · April 2026
+════════════════════════════════════════════════ */
+:root {
+  /* Backgrounds */
+  --bg:           #F8F4F4;
+  --surface:      #FFFFFF;
+  --surface-soft: #F4F0F0;
+  --surface-brief:#F6F2F2;
+  --surface-row:  #FBF8F8;
+  --header-tint:  #EAE7E7;
+  --exec-trigger: #EEF1F8;
+  --table-sub:    #F0ECEC;
+  --sticky-head:  #E7E3E3;
+  --sticky-body:  #FCFAFA;
+  --method-note:  #FBF9F9;
+  --share-metric: #FAF8F8;
+  /* Text */
+  --text:         #283771;
+  --text-muted:   #586390;
+  --text-header:  #46537F;
+  --text-body:    #1A2545;
+  /* Borders */
+  --border:       #E0DEDE;
+  --border-accent:#D6D2D2;
+  /* Brand / accents */
+  --navy:         #283771;
+  --navy-hover:   #37457B;
+  --green:        #2F5E52;
+  --red:          #8D2E2E;
+  --fg:           #283771;
+  --fg-70:        rgba(40,55,113,.7);
+  --fg-80:        rgba(40,55,113,.8);
+  /* Soft transparent tones */
+  --navy-soft:    rgba(40,55,113,0.08);
+  --navy-select:  rgba(40,55,113,0.18);
+  --red-soft:     rgba(141,46,46,0.04);
+  --green-soft:   rgba(47,94,82,0.05);
+  --red-medium:   rgba(141,46,46,0.10);
+  --green-medium: rgba(47,94,82,0.10);
+  --content-width: 860px;
+  --content-width-wide: 1080px;
+  /* Typography (aligned with existing report system) */
+  --font: 'IBM Plex Sans', ui-sans-serif, system-ui, sans-serif;
+  --serif: 'IBM Plex Serif', serif;
+  --mono: 'IBM Plex Mono', 'Courier New', monospace;
+}
+
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{font-size:16px;scroll-behavior:smooth}
+body{background:var(--bg);color:var(--text);font-family:var(--font);line-height:1.72;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+nav{font-family:ui-sans-serif,system-ui,sans-serif;--fg-70:var(--fg);--fg-80:var(--fg)}
+
+.btn-primary{background-color:var(--navy);transition:background-color .15s;color:#fff}
+.btn-primary:hover{background-color:var(--navy-hover)}
+.glass-effect{background:#fff;border:1px solid var(--border);box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.nav-products-dropdown{opacity:0;visibility:hidden;transition:opacity .15s,visibility .15s}
+.group:hover .nav-products-dropdown{opacity:1;visibility:visible}
+
+/* ── NAVIGATION ── */
+.site-nav{
+  background:rgba(255,255,255,0.5);
+  backdrop-filter:blur(10px);
+  -webkit-backdrop-filter:blur(10px);
+  border-bottom:1px solid var(--border);
+  position:sticky;top:0;z-index:100
+}
+.nav-inner{max-width:1100px;margin:0 auto;padding:0 40px;display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{font-family:var(--font);font-size:.9rem;font-weight:700;color:var(--navy);text-decoration:none;letter-spacing:-.01em}
+.nav-logo span{color:var(--red)}
+.nav-links{display:flex;gap:32px;list-style:none}
+.nav-links a{font-family:var(--font);font-size:.74rem;font-weight:500;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);text-decoration:none;transition:color .15s}
+.nav-links a:hover,.nav-links .nav-active{color:var(--navy)}
+
+/* ── LAYOUT ── */
+.content{max-width:var(--content-width);margin:0 auto;padding:0 2rem 4.75rem}
+.content-wide{max-width:var(--content-width-wide);margin:0 auto;padding:0 2rem}
+/* Q1-style breakout when wide content is nested inside main content column. */
+.content > .content-wide{margin-left:-110px;margin-right:-110px;padding-left:0;padding-right:0}
+
+/* ── COVER ── */
+.cover{
+  border-bottom:1px solid var(--border);
+  padding:calc(2.5rem + 64px) 0 2rem;
+  background:linear-gradient(180deg,#FFFFFF 0%,var(--bg) 100%);
+  position:relative;overflow:hidden
+}
+.cover::before{
+  content:none
+}
+.cover::after{
+  content:none
+}
+.cover-inner{max-width:780px;margin:0 auto;padding:0 24px;position:relative}
+.cover-eyebrow{
+  font-family:var(--font);font-size:.7rem;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;
+  color:var(--green);margin-bottom:16px;display:block
+}
+.cover-eyebrow::before{content:none}
+.cover-title{
+  font-family:var(--font);font-size:2.35rem;font-weight:700;line-height:1.22;
+  letter-spacing:-.3px;color:#1A2550;margin-bottom:18px
+}
+.cover-title em{font-style:normal;font-weight:700;color:#1A2550}
+.cover-subtitle{
+  font-family:var(--serif);font-size:1.08rem;font-weight:400;font-style:italic;color:#4A4A4A;
+  max-width:760px;margin-bottom:24px;line-height:1.6
+}
+.cover-meta{margin-top:1.5rem;display:flex;gap:1.2rem;flex-wrap:wrap}
+.cover-meta-item{font-family:var(--mono);font-size:.7rem;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted)}
+.cover-meta-label{color:var(--text-muted);margin-bottom:.3rem}
+.cover-meta-value{color:var(--text)}
+.cover-disclaimer{
+  margin-top:1.2rem;font-family:var(--mono);font-size:.65rem;
+  color:var(--text-muted);line-height:1.6;max-width:760px;
+  border-top:1px solid var(--border);padding-top:.8rem
+}
+
+/* ── BOARD FAST-PATH ── */
+.fastpath{background:var(--exec-trigger);border-bottom:1px solid var(--border)}
+.fastpath-inner{max-width:1100px;margin:0 auto;padding:52px 40px}
+.fastpath-label{font-family:var(--mono);font-size:.6rem;letter-spacing:.2em;text-transform:uppercase;color:var(--text-muted);margin-bottom:10px;display:block}
+.fastpath-title{font-size:1.45rem;font-weight:600;color:var(--navy);margin-bottom:28px;line-height:1.3;letter-spacing:-.02em}
+.fastpath-grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--border-accent)}
+.fastpath-cell{background:var(--surface);padding:28px 24px}
+.fastpath-cell:nth-child(5){grid-column:1/-1;border-top:none;border-left:4px solid var(--navy);background:var(--exec-trigger)}
+.fastpath-num{font-family:var(--mono);font-size:.6rem;color:var(--navy);letter-spacing:.1em;margin-bottom:10px;display:block;text-transform:uppercase;font-weight:500}
+.fastpath-cell p{font-size:.9rem;line-height:1.68;color:var(--text-muted)}
+.fastpath-cell strong{color:var(--navy);font-weight:600}
+
+/* ── PAGE STRUCTURE ── */
+.section-rule{border:none;height:1px;margin:64px 0 0;background:linear-gradient(90deg,transparent,var(--border-accent) 20%,var(--border-accent) 80%,transparent)}
+.part-header{padding:56px 0 0;margin-bottom:32px}
+.part-number{font-family:var(--mono);font-size:.6rem;letter-spacing:.2em;text-transform:uppercase;color:var(--text-muted);margin-bottom:10px;display:flex;align-items:center;gap:10px}
+.part-number::before{content:'';width:20px;height:1px;background:var(--text-muted);display:inline-block;flex-shrink:0}
+.part-title{font-family:var(--serif);font-size:clamp(1.5rem,2.8vw,1.76rem);font-weight:600;line-height:1.22;letter-spacing:-.018em;color:var(--navy)}
+.part-title em{font-style:italic;font-weight:400;color:var(--text-muted)}
+
+/* ── BODY ── */
+p{margin-bottom:1.3em;font-size:1rem;line-height:1.68;color:var(--text-body)}
+p:last-child{margin-bottom:0}
+strong{font-weight:600;color:var(--navy)}
+a{color:var(--navy);text-decoration:none;border-bottom:1px solid var(--navy-soft);transition:border-color .15s}
+a:hover{border-color:var(--navy);color:var(--navy-hover)}
+
+/* ── ARC MARKERS ── */
+.arc-marker{
+  background:var(--exec-trigger);
+  border-left:4px solid var(--navy);
+  padding:20px 24px;margin:60px 0 52px;
+  display:flex;align-items:center;gap:20px
+}
+.arc-marker-num{font-family:var(--mono);font-size:.58rem;color:var(--text-muted);letter-spacing:.14em;text-transform:uppercase;flex-shrink:0;font-weight:500;white-space:nowrap}
+.arc-marker-text{font-size:1.1rem;font-style:italic;font-weight:600;color:var(--navy);line-height:1.4;letter-spacing:-.01em}
+
+/* ── SINGULAR DISCONTINUITY ── */
+.discontinuity{
+  background:var(--navy);
+  padding:44px 48px 40px;margin:36px 0 44px;position:relative;
+  overflow:hidden
+}
+.discontinuity::before{
+  content:'';position:absolute;top:0;right:0;width:50%;height:100%;
+  background:radial-gradient(ellipse at 80% 50%,rgba(47,94,82,.3) 0%,transparent 60%);
+  pointer-events:none
+}
+.discontinuity::after{
+  content:'\201C';position:absolute;top:-20px;left:32px;
+  font-size:10rem;font-weight:700;line-height:1;color:rgba(255,255,255,.06);
+  font-family:Georgia,serif;pointer-events:none;user-select:none
+}
+.discontinuity-label{font-family:var(--mono);font-size:.58rem;letter-spacing:.18em;text-transform:uppercase;color:rgba(255,255,255,.35);margin-bottom:20px;display:block;position:relative}
+.discontinuity blockquote{
+  font-size:clamp(1.2rem,2.4vw,1.65rem);font-weight:600;font-style:italic;
+  line-height:1.5;color:#fff;border:none;padding:0;margin-bottom:18px;letter-spacing:-.015em;
+  position:relative
+}
+.discontinuity cite{font-family:var(--mono);font-size:.62rem;color:rgba(255,255,255,.4);letter-spacing:.06em;font-style:normal;line-height:1.55;display:block}
+
+/* ── EXEC SUMMARY ── */
+.exec-summary{background:var(--exec-trigger);border-left:3px solid var(--navy);padding:36px 40px;margin:44px 0}
+.exec-label{font-family:var(--mono);font-size:.6rem;letter-spacing:.2em;text-transform:uppercase;color:var(--navy);margin-bottom:18px;display:block;font-weight:500}
+.exec-summary p{font-size:1rem;line-height:1.7;color:var(--text-body)}
+.exec-summary p+p{margin-top:14px}
+
+/* ── THESIS BOX ── */
+.thesis-box{border:1.5px solid var(--navy);padding:32px 36px;margin:36px 0;position:relative;background:var(--navy-soft)}
+.thesis-box::before{
+  content:'Central Thesis';position:absolute;top:-9px;left:20px;
+  background:var(--bg);padding:0 10px;font-family:var(--mono);
+  font-size:.58rem;letter-spacing:.18em;text-transform:uppercase;color:var(--navy);font-weight:500
+}
+.thesis-box p{font-size:1.05rem;font-weight:500;font-style:italic;line-height:1.65;color:var(--navy);margin:0}
+
+/* ── PULL QUOTE ── */
+.pull-quote{border-top:2px solid var(--navy);padding:28px 0 24px;margin:48px 0 40px;position:relative}
+.pull-quote::before{
+  content:'\201C';position:absolute;top:-18px;left:-6px;
+  font-size:5rem;font-weight:700;line-height:1;color:var(--navy-soft);
+  font-family:Georgia,serif;pointer-events:none;user-select:none
+}
+.pull-quote p{font-size:1.25rem;font-style:italic;font-weight:500;line-height:1.55;color:var(--navy);margin:0;letter-spacing:-.015em;padding-left:28px}
+
+/* ── EXECUTIVE QUOTE ── */
+.exec-quote{border-left:2px solid var(--green);padding:14px 20px;margin:22px 0;background:var(--green-soft)}
+.exec-quote p{font-size:.97rem;font-style:italic;line-height:1.6;color:var(--text-body);margin-bottom:6px}
+.exec-quote cite{font-family:var(--mono);font-size:.62rem;color:var(--text-muted);letter-spacing:.07em;font-style:normal}
+
+/* ── STAT GRID ── */
+.stat-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;margin:36px 0;background:var(--border-accent);border:1px solid var(--border-accent)}
+.stat-cell{background:var(--surface);padding:26px 22px 22px;border-top:3px solid var(--navy)}
+.stat-cell.stat-alert{border-top-color:var(--red)}
+.stat-number{font-size:1.95rem;font-weight:700;color:var(--navy);line-height:1;display:block;margin-bottom:10px;letter-spacing:-.03em}
+.stat-cell.stat-alert .stat-number{color:var(--red)}
+.stat-label{font-family:var(--mono);font-size:.6rem;letter-spacing:.07em;text-transform:uppercase;color:var(--text-muted);line-height:1.6}
+
+/* ── TABLES (aligned with existing report style) ── */
+.table-wrap{margin:28px 0 36px;overflow-x:auto;border:1px solid var(--border)}
+.table-wrap.wide{margin-left:-110px;margin-right:-110px}
+.table-label{font-family:var(--mono);font-size:.62rem;letter-spacing:.12em;text-transform:uppercase;color:var(--navy);margin-bottom:10px;display:block;font-weight:500}
+table{width:100%;border-collapse:collapse;font-size:.84rem;line-height:1.5}
+thead{background:var(--header-tint)}
+thead th{
+  font-family:var(--mono);font-size:.72rem;letter-spacing:.06em;text-transform:uppercase;
+  font-weight:700;padding:10px 13px;text-align:left;
+  color:var(--text-header);border-bottom:1px solid var(--border-accent);white-space:nowrap
+}
+thead th:first-child{background:var(--sticky-head)}
+tbody tr{border-bottom:1px solid var(--border)}
+tbody tr:nth-child(even){background:var(--surface-row)}
+tbody tr:hover{background:var(--navy-soft)}
+tbody td{padding:9px 13px;vertical-align:top;color:var(--text);font-size:.84rem;line-height:1.52}
+tbody td:first-child{background:var(--sticky-body)}
+.td-bold{font-weight:600;color:var(--navy)}
+.td-number{font-family:var(--mono);font-weight:600;color:var(--navy);white-space:nowrap;font-size:.72rem}
+.td-none{
+  font-family:var(--mono);font-size:.72rem;
+  background:var(--red-medium);color:var(--red);
+  padding:2px 8px;display:inline-block;font-weight:600;
+  border:1px solid rgba(141,46,46,.2)
+}
+.td-yes{font-family:var(--mono);font-size:.72rem;color:var(--green);font-weight:600}
+.td-diligence{font-family:var(--mono);font-size:.72rem;color:#7B5E2A;font-weight:500}
+
+/* ── ATTACK TAXONOMY ── */
+.taxonomy{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;margin:28px 0;background:var(--border);border:1px solid var(--border)}
+.taxonomy-cell{background:var(--surface);padding:24px 22px;border-top:3px solid var(--navy)}
+.taxonomy-label{font-family:var(--mono);font-size:.6rem;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:10px;display:block}
+.taxonomy-name{font-size:1rem;font-weight:700;color:var(--navy);margin-bottom:10px;line-height:1.25;letter-spacing:-.01em}
+.taxonomy-desc{font-size:.84rem;color:var(--text-muted);line-height:1.58}
+.taxonomy-example{font-family:var(--mono);font-size:.63rem;color:var(--green);margin-top:12px;display:block;font-weight:500}
+
+/* ── CALLOUT ── */
+.callout-box{background:var(--surface-soft);border-left:3px solid var(--green);padding:24px 28px;margin:28px 0}
+.callout-box p{font-size:.9rem;line-height:1.66;color:var(--text-body);margin-bottom:.7em}
+.callout-box p:last-child{margin-bottom:0}
+.callout-box strong{color:var(--navy)}
+
+/* ── VERDICT BOX ── */
+.verdict-box{border:1px solid rgba(141,46,46,.35);border-left:4px solid var(--red);padding:28px 32px;margin:36px 0;background:var(--red-soft)}
+.verdict-label{font-family:var(--mono);font-size:.6rem;letter-spacing:.18em;text-transform:uppercase;color:var(--red);margin-bottom:12px;display:block;font-weight:500}
+.verdict-box p{font-size:1rem;font-weight:600;line-height:1.7;color:var(--text-body);margin:0}
+
+/* ── CATEGORY BOX ── */
+.category-box{
+  background:linear-gradient(135deg,var(--navy) 0%,#1A2545 100%);
+  color:#fff;padding:44px 48px;margin:52px 0;position:relative;overflow:hidden
+}
+.category-box::before{
+  content:'';position:absolute;top:0;right:0;width:45%;height:100%;
+  background:radial-gradient(ellipse at 80% 50%,rgba(47,94,82,.25) 0%,transparent 65%);
+  pointer-events:none
+}
+.category-label{font-family:var(--mono);font-size:.6rem;letter-spacing:.2em;text-transform:uppercase;color:rgba(255,255,255,.4);margin-bottom:16px;display:block}
+.category-box h3{font-size:clamp(1.3rem,2.5vw,1.75rem);font-weight:600;font-style:italic;line-height:1.3;color:#fff;margin-bottom:18px;letter-spacing:-.015em;position:relative}
+.category-box p{font-size:.95rem;line-height:1.7;color:rgba(255,255,255,.72);position:relative}
+
+/* ── ENTERPRISE TRACE ── */
+.trace{margin:36px 0;background:var(--surface);padding:32px 36px;border:1px solid var(--border);border-top:3px solid var(--navy)}
+.trace-label{font-family:var(--mono);font-size:.58rem;letter-spacing:.18em;text-transform:uppercase;color:var(--text-muted);margin-bottom:16px;display:block}
+.trace-title{font-size:1.05rem;font-weight:600;color:var(--navy);margin-bottom:20px;line-height:1.3;letter-spacing:-.01em}
+.trace-chain{display:flex;flex-wrap:wrap;gap:1px;margin-bottom:20px;background:var(--border-accent)}
+.trace-node{background:var(--exec-trigger);padding:10px 14px;flex:1;min-width:130px}
+.trace-node-label{font-family:var(--mono);font-size:.55rem;text-transform:uppercase;letter-spacing:.1em;display:block;margin-bottom:4px;color:var(--text-muted)}
+.trace-node-name{font-family:var(--mono);font-size:.67rem;color:var(--navy);display:block;line-height:1.4;font-weight:500}
+.trace p{font-size:.9rem;line-height:1.65;color:var(--text-body)}
+
+/* ── CONCLUSION CTA BLOCK ── */
+.conclusion-cta{background:var(--navy);padding:36px 40px;margin:44px 0;position:relative;overflow:hidden}
+.conclusion-cta::before{content:'';position:absolute;top:0;right:0;width:40%;height:100%;background:radial-gradient(ellipse at 80% 50%,rgba(47,94,82,.2) 0%,transparent 65%);pointer-events:none}
+.conclusion-cta-eyebrow{font-family:var(--mono);font-size:.58rem;letter-spacing:.2em;text-transform:uppercase;color:rgba(255,255,255,.4);margin-bottom:12px;display:block;position:relative}
+.conclusion-cta-heading{font-size:1.15rem;font-weight:600;color:#fff;letter-spacing:-.015em;margin-bottom:10px;line-height:1.3;position:relative}
+.conclusion-cta-desc{font-size:.9rem;color:rgba(255,255,255,.65);line-height:1.68;max-width:580px;margin-bottom:24px;position:relative}
+.conclusion-cta-contacts{display:flex;gap:20px;flex-wrap:wrap;position:relative}
+.conclusion-cta-contact{display:flex;flex-direction:column;gap:4px;font-family:var(--mono);font-size:.68rem;color:rgba(255,255,255,.9);text-decoration:none;border:1px solid rgba(255,255,255,.2);padding:12px 16px;min-width:220px;transition:border-color .2s}
+.conclusion-cta-contact:hover{border-color:rgba(255,255,255,.5);border-bottom-color:rgba(255,255,255,.5)}
+.conclusion-cta-contact span:first-child{color:rgba(255,255,255,.42);font-size:.6rem;letter-spacing:.1em;text-transform:uppercase}
+@media(max-width:700px){.conclusion-cta{padding:28px 20px}.conclusion-cta-contacts{flex-direction:column}}
+.conviction-box{
+  background:var(--navy);
+  padding:32px 36px;margin:36px 0;position:relative;overflow:hidden
+}
+.conviction-box::before{
+  content:'';position:absolute;top:0;right:0;width:40%;height:100%;
+  background:radial-gradient(ellipse at 80% 50%,rgba(47,94,82,.2) 0%,transparent 65%);
+  pointer-events:none
+}
+.conviction-label{
+  font-family:var(--mono);font-size:.58rem;letter-spacing:.2em;text-transform:uppercase;
+  color:rgba(255,255,255,.45);margin-bottom:14px;display:block;position:relative
+}
+.conviction-box p{
+  font-size:.97rem;font-weight:400;line-height:1.75;color:rgba(255,255,255,.85);
+  margin:0;position:relative
+}
+.conviction-box strong{color:#fff;font-weight:700}
+
+/* ── VERDICT BOX GREEN (Section 15 verdict) ── */
+.verdict-box-green{border:1px solid rgba(47,94,82,.35);border-left:4px solid var(--green);padding:28px 32px;margin:36px 0;background:var(--green-soft)}
+.verdict-box-green .verdict-label{color:var(--green)}
+.verdict-box-green p{font-size:1rem;font-weight:600;line-height:1.7;color:var(--text-body);margin:0}
+
+/* ── ANSWERS BOX (LLM retrieval) ── */
+.answers-box{border:1px solid var(--border);border-left:4px solid var(--navy);padding:22px 28px;margin:32px 0;background:var(--surface)}
+.answers-box-title{font-family:var(--mono);font-size:.62rem;letter-spacing:.16em;text-transform:uppercase;color:var(--navy);font-weight:600;margin-bottom:14px;display:block}
+.answers-grid{display:grid;grid-template-columns:1fr 1fr;gap:4px 24px}
+.answers-item{font-size:.82rem;color:var(--text-muted);line-height:1.5;padding:3px 0}
+.answers-item::before{content:"→ ";color:var(--navy);font-weight:700}
+@media(max-width:700px){.answers-grid{grid-template-columns:1fr}}
+
+/* ── SELF-IDENTIFICATION MATRIX ── */
+.self-id-section{margin:36px 0}
+.self-id-label{font-family:var(--mono);font-size:.62rem;letter-spacing:.18em;text-transform:uppercase;color:var(--red);font-weight:600;margin-bottom:6px;display:block}
+.self-id-title{font-size:1.1rem;font-weight:700;color:var(--navy);margin-bottom:18px;line-height:1.3}
+.self-id-section table td:first-child{font-weight:700;color:var(--navy);font-size:.82rem}
+.self-id-section table td{font-size:.8rem}
+
+/* ── METHODOLOGY LEGEND ── */
+.methodology-box{border:1px solid var(--border);margin:28px 0;background:var(--surface);overflow:hidden}
+.methodology-title{font-family:var(--mono);font-size:.62rem;letter-spacing:.16em;text-transform:uppercase;color:#fff;font-weight:600;background:var(--navy);padding:12px 28px;display:block;margin:0}
+.methodology-row{display:flex;gap:14px;padding:12px 28px;border-bottom:1px solid var(--border);font-size:.82rem}
+.methodology-row:last-child{border-bottom:none}
+.methodology-term{font-weight:700;color:var(--navy);min-width:180px;font-family:var(--mono);font-size:.75rem;letter-spacing:.03em;flex-shrink:0}
+.methodology-def{color:var(--text-muted);line-height:1.55}
+@media(max-width:700px){.methodology-row{flex-direction:column;gap:4px;padding:10px 20px}.methodology-term{min-width:unset}.methodology-title{padding:10px 20px}}
+
+/* ── MOAT GRID — primary moat differentiated ── */
+.moat-grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;margin:28px 0;background:var(--border)}
+.moat-cell{background:var(--surface);padding:28px 24px;border-top:3px solid var(--navy)}
+.moat-cell.moat-primary{border-top-color:var(--green);background:var(--green-soft)}
+.moat-num{font-family:var(--mono);font-size:.6rem;color:var(--text-muted);letter-spacing:.15em;margin-bottom:8px;display:block}
+.moat-cell.moat-primary .moat-num{color:var(--green)}
+.moat-name{font-size:1rem;font-weight:700;color:var(--navy);margin-bottom:12px;line-height:1.25;letter-spacing:-.01em}
+.moat-desc{font-size:.87rem;color:var(--text-muted);line-height:1.65;margin-bottom:12px}
+.moat-tag{font-family:var(--mono);font-size:.62rem;color:var(--green);background:var(--green-soft);padding:4px 10px;display:inline-block;border:1px solid rgba(47,94,82,.2);font-weight:500}
+.moat-cell.moat-primary .moat-tag{background:rgba(47,94,82,.15);border-color:rgba(47,94,82,.35)}
+
+/* ── PDF BUTTON ── */
+.pdf-btn{
+  display:inline-flex;align-items:center;gap:8px;
+  font-family:var(--mono);font-size:.65rem;letter-spacing:.12em;text-transform:uppercase;
+  color:#fff;background:var(--navy);
+  border:1px solid var(--navy);padding:11px 22px;
+  cursor:pointer;transition:all .2s;margin-top:28px;
+  text-decoration:none;outline:none
+}
+.pdf-btn:hover{
+  background:var(--navy-hover);border-color:var(--navy-hover);
+  color:#fff
+}
+.pdf-btn svg{width:14px;height:14px;flex-shrink:0;opacity:.85}
+
+/* ── TAM STRIP ── */
+.tam-strip{background:var(--surface);border:1px solid var(--border);margin:32px 0}
+.tam-inner{display:grid;grid-template-columns:1fr 1fr 1fr;gap:0}
+.tam-cell{padding:28px 24px;border-right:1px solid var(--border);border-top:3px solid var(--navy-soft)}
+.tam-cell:first-child{border-top-color:var(--red)}
+.tam-cell:nth-child(2){border-top-color:var(--navy)}
+.tam-cell:last-child{border-right:none;border-top-color:var(--green)}
+.tam-number{font-size:1.75rem;font-weight:700;color:var(--navy);display:block;margin-bottom:8px;line-height:1;letter-spacing:-.025em}
+.tam-cell:first-child .tam-number{color:var(--red)}
+.tam-cell:last-child .tam-number{color:var(--green)}
+.tam-label{font-family:var(--mono);font-size:.6rem;color:var(--text-muted);letter-spacing:.08em;text-transform:uppercase;line-height:1.58}
+
+.share-panel-num{font-size:2.2rem;font-weight:700;color:#fff;letter-spacing:-.025em;margin-bottom:10px;display:block;line-height:1}
+.share-panel-desc{font-family:var(--font);font-size:.72rem;color:#fff;line-height:1.62;letter-spacing:.01em}
+
+/* ── PRINT / PDF EXPORT (aligned with already-broken-quantum-risk-report-q1-2026: @page top/bottom only; no extra .content horizontal padding; wide breakout zeroed in print) ── */
+@media print{
+  @page{margin-top:.35in;margin-bottom:.35in}
+  :root{
+    --bg:#fff;
+    --surface:#fff;
+    --surface-soft:#f7f7f7;
+    --surface-brief:#f7f7f7;
+    --surface-row:#fafafa;
+    --header-tint:#ececec;
+    --exec-trigger:#f7f7f7;
+    --table-sub:#ececec;
+    --sticky-head:#ececec;
+    --sticky-body:#fafafa;
+    --method-note:#fff;
+    --share-metric:#fff;
+    --border:#d7d7d7;
+    --border-accent:#cfcfcf
+  }
+  *{-webkit-print-color-adjust:exact;print-color-adjust:exact}
+  body{background:#fff}
+  .site-nav,.pdf-btn,.author-photo-slot,.connect-actions,.no-print{display:none!important}
+  .manual-page-break{break-before:page;page-break-before:always;height:0!important;margin:0!important;padding:0!important}
+  .cover,.fastpath,.team-section,.connect-section,.report-footer,.case-study,.verdict-box,.verdict-box-green{
+    box-shadow:none!important;background:#fff!important
+  }
+  .chart-wrap,.exec-quote,.verdict-box,.callout-box,.faq-item,.team-card{page-break-inside:avoid}
+  /* Fill the full available print width — prevents max-width + margin:auto from centering at viewport width */
+  .content{max-width:none!important;margin-left:0!important;margin-right:0!important}
+  .cover-inner,.fastpath-inner{max-width:none!important;margin-left:0!important;margin-right:0!important;padding-left:2rem!important;padding-right:2rem!important}
+  .content-wide{margin-left:0!important;margin-right:0!important;padding-left:0!important;padding-right:0!important}
+  .section{page-break-inside:auto!important;break-inside:auto!important}
+  .section-rule{background:#E0DEDE;height:1px;border:none;margin:40px 0 0}
+  .pull-quote::before,.discontinuity::after{display:none}
+  .table-wrap.wide{margin-left:0!important;margin-right:0!important}
+  .table-wrap{overflow:visible!important;background:#fff!important}
+  .table-wrap table th:first-child,.table-wrap table td:first-child{position:static!important;box-shadow:none!important}
+  .faq-item{border-color:#d9d9d9!important}
+  .faq-item summary::after{display:none!important}
+  .faq-item:not([open]) .faq-a{display:block!important}
+  .stat-grid,.taxonomy,.moat-grid,.framework-grid,.fastpath-grid,.toc-grid{break-inside:avoid}
+  h2{break-after:avoid}
+  .part-header{padding-top:32px}
+  a{color:var(--navy)!important;border-bottom:none!important}
+}
+
+/* ── CASE STUDY ── */
+.case-study{border:1px solid var(--border);margin:32px 0;background:var(--surface);overflow:hidden}
+.case-study-header{background:var(--navy);padding:20px 28px}
+.case-label{font-family:var(--mono);font-size:.58rem;letter-spacing:.18em;text-transform:uppercase;color:rgba(255,255,255,.45);margin-bottom:6px;display:block}
+.case-title{font-size:1rem;font-weight:600;color:#fff;line-height:1.3;letter-spacing:-.01em}
+.case-meta{display:flex;gap:0;flex-wrap:nowrap;border-bottom:1px solid var(--border)}
+.case-meta-item{font-family:var(--mono);font-size:.62rem;color:var(--text-muted);padding:14px 20px;border-right:1px solid var(--border);flex:1}
+.case-meta-item:last-child{border-right:none}
+.case-meta-item strong{display:block;color:var(--red);font-size:.9rem;font-family:var(--font);margin-bottom:2px;font-weight:700}
+.case-body{padding:24px 28px}
+.case-body p{font-size:.9rem}
+
+/* ── SCENARIO ── */
+.scenario{border:1px solid var(--border-accent);padding:24px 28px;margin:24px 0;background:var(--surface-brief)}
+.scenario-label{font-family:var(--mono);font-size:.58rem;letter-spacing:.15em;text-transform:uppercase;color:var(--green);margin-bottom:12px;display:block;font-weight:500}
+.scenario p{font-size:.9rem;color:var(--text-muted);line-height:1.68}
+
+/* ── FRAMEWORK GRID ── */
+.framework-grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;margin:28px 0;background:var(--border)}
+.framework-cell{background:var(--surface);padding:24px 22px;border-top:2px solid var(--navy)}
+.framework-q{font-size:.97rem;font-weight:700;color:var(--navy);margin-bottom:10px;line-height:1.3;display:block;letter-spacing:-.01em}
+.framework-a{font-size:.84rem;color:var(--text-muted);line-height:1.62}
+
+/* ── CONCLUSION ── */
+.conclusion-statement{border-top:2px solid var(--navy);border-bottom:1px solid var(--border);padding:32px 0;margin:44px 0 36px}
+.conclusion-statement p{font-size:clamp(1.1rem,2.2vw,1.6rem);font-weight:600;font-style:italic;line-height:1.45;color:var(--navy);margin:0;letter-spacing:-.015em}
+
+/* ── TOC ── */
+.toc{background:var(--surface);border:1px solid var(--border);border-top:3px solid var(--navy);padding:32px 36px;margin:44px 0}
+.toc-title{font-family:var(--mono);font-size:.6rem;letter-spacing:.22em;text-transform:uppercase;color:var(--navy);margin-bottom:20px;display:block;font-weight:500}
+.toc-grid{display:grid;grid-template-columns:1fr 1fr;gap:0 32px}
+.toc-item{display:flex;align-items:baseline;gap:10px;padding:7px 0;border-bottom:1px dotted var(--border-accent);text-decoration:none;color:var(--text-muted);transition:color .15s}
+.toc-item:hover{color:var(--navy)}
+.toc-num{font-family:var(--mono);font-size:.6rem;color:var(--navy);flex-shrink:0;min-width:26px;font-weight:600}
+.toc-text{font-size:.84rem;line-height:1.45}
+
+/* ── FAQ ACCORDION ── */
+.faq-section{margin:56px 0}
+details.faq-item{border-bottom:1px solid var(--border)}
+details.faq-item[open]{border-bottom:2px solid var(--border-accent)}
+summary.faq-q{
+  font-size:.97rem;font-weight:600;color:var(--navy);
+  padding:20px 36px 20px 0;line-height:1.4;letter-spacing:-.01em;
+  cursor:pointer;list-style:none;position:relative;user-select:none;
+  transition:color .15s
+}
+summary.faq-q::-webkit-details-marker{display:none}
+summary.faq-q::after{
+  content:'';position:absolute;right:2px;top:50%;transform:translateY(-50%) rotate(0deg);
+  width:16px;height:16px;transition:transform .2s ease;flex-shrink:0;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none'%3E%3Cpath d='M4 6l4 4 4-4' stroke='%23283771' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat:no-repeat;background-position:center;background-size:contain
+}
+details.faq-item[open] summary.faq-q::after{transform:translateY(-50%) rotate(180deg)}
+summary.faq-q:hover{color:var(--navy-hover)}
+.faq-a{font-size:.9rem;color:var(--text-muted);line-height:1.72;padding:0 36px 20px 0;border-top:1px solid var(--border)}
+
+/* ── AUTHOR PHOTO ── */
+.author-photo{width:76px;height:76px;border-radius:50%;background:var(--navy-soft);border:2px solid var(--border-accent);margin-bottom:18px;display:flex;align-items:center;justify-content:center;overflow:hidden;flex-shrink:0}
+.author-photo img{width:100%;height:100%;object-fit:cover;border-radius:50%}
+.author-photo-placeholder{font-family:var(--font);font-size:1.3rem;font-weight:700;color:var(--navy);letter-spacing:-.02em;opacity:.5}
+.author-photo-slot{width:76px;height:76px;border-radius:50%;border:2px dashed var(--border-accent);margin-bottom:18px;display:flex;align-items:center;justify-content:center;background:var(--surface-soft)}
+.author-photo-slot span{font-family:var(--mono);font-size:.55rem;letter-spacing:.08em;text-transform:uppercase;color:var(--text-muted);text-align:center;line-height:1.4}
+
+/* ── FOOTNOTES ── */
+.footnote-section{border-top:1px solid var(--border);padding:28px 0 44px;margin-top:60px;background:var(--method-note)}
+.footnote-section p{font-family:var(--mono);font-size:.66rem;line-height:1.6;color:var(--text-muted);margin-bottom:5px}
+
+/* ── FOOTER ── */
+.report-footer{background:var(--bg);border-top:1px solid var(--border);padding:3rem 0}
+.report-footer-inner{max-width:860px;margin:0 auto;padding:0 40px}
+.report-footer h3{font-size:.7rem;font-weight:600;color:var(--text-muted);margin-bottom:1rem;letter-spacing:.08em;text-transform:uppercase}
+.report-footer p{font-size:.75rem;color:var(--text-muted);line-height:1.72;margin-bottom:.8rem}
+.footer-inner{max-width:1100px;margin:0 auto;padding:0 40px;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px}
+.footer-brand{font-family:var(--mono);font-size:.65rem;letter-spacing:.14em;text-transform:uppercase;color:rgba(255,255,255,.5)}
+.footer-brand span{color:rgba(255,255,255,.9)}
+.footer-disclaimer{font-family:var(--mono);font-size:.6rem;color:rgba(255,255,255,.35);max-width:480px;line-height:1.55}
+
+/* ── METHODOLOGY NOTE ── */
+.method-note{background:var(--method-note);border:1px solid var(--border);padding:16px 20px;margin:20px 0}
+.method-note p{font-family:var(--mono);font-size:.68rem;color:var(--text-muted);line-height:1.6;margin-bottom:.5em}
+.method-note p:last-child{margin-bottom:0}
+
+/* ── UTILITY ── */
+.section-sub{font-family:var(--mono);font-size:.64rem;letter-spacing:.14em;text-transform:uppercase;color:var(--text-muted);margin-bottom:8px;display:block;margin-top:36px}
+.stat-footnote{font-family:var(--mono);font-size:.63rem;color:var(--text-muted);margin-top:-20px;margin-bottom:32px;line-height:1.5}
+
+/* ── CHARTS & VISUALIZATIONS ── */
+/* TPS Bar Chart */
+.chart-wrap{background:var(--surface);border:1px solid var(--border);padding:28px 28px 20px;margin:28px 0}
+.chart-title{font-family:var(--mono);font-size:.6rem;letter-spacing:.14em;text-transform:uppercase;color:var(--text-muted);margin-bottom:20px;display:block}
+.tps-bar-row{display:flex;align-items:center;gap:14px;margin-bottom:10px}
+.tps-bar-row:last-child{margin-bottom:0}
+.tps-bar-label{font-family:var(--mono);font-size:.68rem;color:var(--text-body);min-width:110px;line-height:1.35;flex-shrink:0;text-align:right}
+.tps-bar-label span{display:block;font-size:.58rem;color:var(--text-muted);margin-top:2px}
+.tps-bar-track{flex:1;background:var(--surface-soft);height:28px;position:relative;border:1px solid var(--border)}
+.tps-bar-fill{height:100%;display:flex;align-items:center;justify-content:flex-end;padding-right:8px;font-family:var(--mono);font-size:.7rem;font-weight:600;color:#fff;white-space:nowrap;transition:width .3s}
+.tps-bar-fill.critical{background:#8D2E2E}
+.tps-bar-fill.high{background:rgba(141,46,46,.7)}
+.tps-bar-fill.medium{background:#7B5E2A}
+.tps-bar-fill.low{background:rgba(40,55,113,.55)}
+.tps-bar-fill.native{background:var(--green);justify-content:flex-start;padding-right:0;padding-left:8px;color:#fff}
+.tps-legend{display:flex;gap:20px;margin-top:16px;padding-top:14px;border-top:1px solid var(--border);flex-wrap:wrap}
+.tps-legend-item{display:flex;align-items:center;gap:6px;font-family:var(--mono);font-size:.6rem;color:var(--text-muted)}
+.tps-legend-dot{width:10px;height:10px;border-radius:2px;flex-shrink:0}
+
+/* Qubit Timeline Chart */
+.qubit-chart{background:var(--surface);border:1px solid var(--border);padding:28px;margin:28px 0;position:relative;overflow:hidden}
+.qubit-chart::before{content:'';position:absolute;top:0;right:0;width:35%;height:100%;background:radial-gradient(ellipse at 80% 50%,rgba(40,55,113,.04) 0%,transparent 70%);pointer-events:none}
+.qubit-timeline{position:relative;padding:20px 0 10px}
+.qubit-track{display:flex;align-items:flex-end;gap:0;height:180px;position:relative}
+.qubit-track::before{content:'';position:absolute;bottom:0;left:0;right:0;height:1px;background:var(--border)}
+.qubit-col{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:flex-end;gap:0;padding:0 6px;position:relative}
+.qubit-bar{width:100%;max-width:56px;background:var(--navy-soft);border:1px solid var(--border-accent);border-bottom:none;position:relative;transition:height .3s;display:flex;align-items:flex-start;justify-content:center}
+.qubit-bar.b1{background:rgba(141,46,46,.12);border-color:rgba(141,46,46,.25);height:168px}
+.qubit-bar.b2{background:rgba(141,46,46,.10);border-color:rgba(141,46,46,.2);height:140px}
+.qubit-bar.b3{background:rgba(141,46,46,.08);border-color:rgba(141,46,46,.15);height:112px}
+.qubit-bar.b4{background:rgba(40,55,113,.1);border-color:rgba(40,55,113,.2);height:72px}
+.qubit-bar.b5{background:rgba(47,94,82,.15);border-color:rgba(47,94,82,.3);height:24px}
+.qubit-bar-val{font-family:var(--mono);font-size:.62rem;font-weight:600;color:var(--navy);padding-top:6px;text-align:center;line-height:1.3;white-space:nowrap}
+.qubit-col-label{font-family:var(--mono);font-size:.58rem;color:var(--text-muted);text-align:center;margin-top:8px;line-height:1.4}
+.qubit-col-label strong{display:block;color:var(--navy);font-weight:600;margin-bottom:2px}
+.qubit-arrow{position:absolute;top:50%;left:0;right:0;display:flex;align-items:center;pointer-events:none}
+.qubit-trend{width:100%;height:1px;background:linear-gradient(90deg,rgba(141,46,46,.3),rgba(47,94,82,.3));position:absolute;top:40%}
+
+/* Three-Plane Diagram */
+.plane-diagram{margin:28px 0;background:var(--surface);border:1px solid var(--border)}
+.plane-layer{display:grid;grid-template-columns:140px 1fr 1fr;gap:0;border-bottom:1px solid var(--border)}
+.plane-layer:last-child{border-bottom:none}
+.plane-id{padding:22px 20px;display:flex;flex-direction:column;justify-content:center;border-right:1px solid var(--border)}
+.plane-id-num{font-family:var(--mono);font-size:.55rem;letter-spacing:.14em;text-transform:uppercase;color:var(--text-muted);margin-bottom:6px}
+.plane-id-name{font-size:.95rem;font-weight:700;color:var(--navy);line-height:1.2;letter-spacing:-.01em}
+.plane-id-tag{font-family:var(--mono);font-size:.6rem;margin-top:8px;padding:3px 8px;display:inline-block;border:1px solid;font-weight:500}
+.plane-id-tag.asset{color:var(--navy);border-color:var(--navy);background:var(--navy-soft)}
+.plane-id-tag.control{color:var(--red);border-color:rgba(141,46,46,.4);background:rgba(141,46,46,.06)}
+.plane-id-tag.privacy{color:var(--green);border-color:rgba(47,94,82,.4);background:var(--green-soft)}
+.plane-content{padding:18px 20px;border-right:1px solid var(--border)}
+.plane-content-title{font-family:var(--mono);font-size:.58rem;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:10px;display:block}
+.plane-items{list-style:none;padding:0;margin:0}
+.plane-items li{font-size:.82rem;color:var(--text-muted);padding:3px 0;padding-left:12px;position:relative;line-height:1.45}
+.plane-items li::before{content:'·';position:absolute;left:0;color:var(--navy);font-weight:700}
+.plane-items li strong{color:var(--navy)}
+.plane-attack{padding:18px 20px}
+.plane-attack-title{font-family:var(--mono);font-size:.58rem;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:10px;display:block}
+.plane-attack-type{margin-bottom:8px}
+.plane-attack-type:last-child{margin-bottom:0}
+.plane-attack-name{font-family:var(--mono);font-size:.65rem;font-weight:600;margin-bottom:3px}
+.plane-attack-name.critical{color:var(--red)}
+.plane-attack-name.high{color:#7B5E2A}
+.plane-attack-name.medium{color:var(--navy)}
+.plane-attack-desc{font-size:.79rem;color:var(--text-muted);line-height:1.45}
+
+/* Exposure pill tags */
+.exp-tag{font-family:var(--mono);font-size:.6rem;padding:2px 7px;display:inline-block;border:1px solid;font-weight:500;margin:1px 2px;white-space:nowrap}
+.exp-tag.asset{color:var(--navy);border-color:rgba(40,55,113,.35);background:var(--navy-soft)}
+.exp-tag.control{color:var(--red);border-color:rgba(141,46,46,.3);background:rgba(141,46,46,.06)}
+.exp-tag.privacy{color:var(--green);border-color:rgba(47,94,82,.3);background:var(--green-soft)}
+.exp-tag.bridge{color:#7B5E2A;border-color:rgba(123,94,42,.3);background:rgba(245,177,76,.08)}
+
+/* Stop indicator */
+.stop-ind{display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:50%;background:rgba(141,46,46,.12);border:1.5px solid rgba(141,46,46,.4);font-family:var(--mono);font-size:.6rem;font-weight:700;color:var(--red);flex-shrink:0}
+
+/* Shareable panel CSS classes */
+.share-panel{background:var(--navy);color:#fff;padding:40px 0;border-bottom:3px solid rgba(255,255,255,.08)}
+.share-panel-label{font-family:var(--font);font-size:.58rem;letter-spacing:.2em;text-transform:uppercase;color:#fff;margin-bottom:24px;display:block}
+.share-panel-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:rgba(255,255,255,.1)}
+.share-panel-cell{background:var(--navy);padding:22px 20px}
+.share-panel-cell.green-top{border-top:2px solid var(--green)}
+.share-panel-cell.red-top{border-top:2px solid rgba(141,46,46,.7)}
+
+@media(max-width:700px){
+  /* Charts */
+  .tps-bar-label{min-width:80px;font-size:.6rem}
+  .qubit-track{height:120px}
+  .qubit-bar.b1{height:108px}.qubit-bar.b2{height:90px}.qubit-bar.b3{height:72px}.qubit-bar.b4{height:48px}.qubit-bar.b5{height:16px}
+  /* Diagrams */
+  .plane-layer{grid-template-columns:1fr}
+  .plane-id{border-right:none;border-bottom:1px solid var(--border)}
+  .plane-content{border-right:none;border-bottom:1px solid var(--border)}
+  /* Page layout */
+  .content,.content-wide,.fastpath-inner,.cover-inner{padding:0 20px}
+  .content > .content-wide{margin-left:0;margin-right:0}
+  .cover-title{font-size:1.75rem}
+  .cover-meta{gap:20px}
+  /* Grids */
+  .stat-grid{grid-template-columns:1fr 1fr}
+  .moat-grid{grid-template-columns:1fr}
+  .moat-cell{border-top:3px solid var(--navy)}
+  .moat-cell.moat-primary{border-top-color:var(--green)}
+  .framework-grid{grid-template-columns:1fr}
+  .fastpath-grid{grid-template-columns:1fr}
+  .fastpath-cell:nth-child(5){grid-column:1}
+  .toc-grid{grid-template-columns:1fr}
+  .share-panel-grid{grid-template-columns:1fr 1fr}
+  /* TAM strip */
+  .tam-inner{grid-template-columns:1fr!important}
+  .tam-cell{border-right:none;border-bottom:1px solid var(--border)}
+  /* Case study */
+  .case-meta{flex-wrap:wrap}
+  .case-meta-item{min-width:48%;border-bottom:1px solid var(--border)}
+  .table-wrap.wide{margin-left:0;margin-right:0}
+}
+
+/* ── AUTHORS / CONTACT (Q1 parity) ── */
+.team-section,.connect-section{padding-left:2rem;padding-right:2rem}
+.team-inner,.connect-inner{max-width:860px;margin:0 auto}
+.team-section{
+  border-top:2px solid var(--border-accent);
+  padding-top:3rem;
+  padding-bottom:2.5rem;
+  background:var(--bg)
+}
+.team-label{font-size:.68rem;font-weight:700;color:var(--text-muted);margin-bottom:.6rem}
+.team-section h2{font-family:var(--serif);font-size:1.3rem;color:var(--text);margin-bottom:1.5rem}
+.team-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.25rem}
+.team-card{background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:1.2rem 1.2rem 1rem}
+.team-name{font-size:.9rem;font-weight:600;color:var(--text);margin-bottom:.1rem}
+.team-role{font-family:var(--mono);font-size:.62rem;letter-spacing:.08em;text-transform:uppercase;color:var(--navy-hover);margin-bottom:.6rem}
+.team-bio{font-size:.78rem;color:var(--text-muted);line-height:1.55;margin-bottom:.7rem}
+.team-links{font-family:var(--mono);font-size:.62rem;color:var(--text-muted)}
+.team-links a{text-decoration:none}
+.team-links a:hover{color:var(--text)}
+.connect-section{
+  border-top:1px solid var(--border);
+  padding-top:2.5rem;
+  padding-bottom:3rem;
+  background:var(--bg)
+}
+.connect-label{font-size:.68rem;font-weight:700;color:var(--text-muted);margin-bottom:.6rem;text-align:center}
+.connect-section h2{font-family:var(--serif);font-size:1.3rem;color:var(--text);margin-bottom:.6rem;text-align:center}
+.connect-intro{font-size:.9rem;color:var(--text-muted);line-height:1.65;max-width:620px;margin:0 auto 2rem;text-align:center}
+.connect-contacts{display:flex;flex-direction:column;align-items:center;gap:.6rem;margin-bottom:2.5rem}
+.connect-person{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;justify-content:center;font-size:.82rem}
+.connect-person .name{font-weight:600;color:var(--text);min-width:180px;text-align:right}
+.connect-person .role{font-family:var(--mono);font-size:.68rem;color:var(--text-muted);min-width:90px;text-align:left}
+.connect-person .email{font-family:var(--mono);font-size:.75rem;color:var(--navy-hover);text-decoration:none}
+.connect-sep{color:var(--text-muted);margin:0 .25rem}
+.connect-actions{display:flex;justify-content:center;align-items:center;gap:1.25rem;flex-wrap:wrap}
+.connect-btn{display:inline-flex;align-items:center;gap:.5rem;padding:.7rem 1.4rem;border-radius:4px;font-family:var(--mono);font-size:.75rem;font-weight:600;letter-spacing:.06em;text-decoration:none;cursor:pointer;border:none}
+.connect-btn svg{width:16px;height:16px;flex-shrink:0}
+.connect-btn.primary{background:var(--navy);color:#fff}
+.connect-btn.primary:hover{background:var(--navy-hover)}
+.connect-btn.secondary{background:transparent;color:var(--text);border:1px solid var(--border-accent)}
+@media(max-width:700px){
+  .team-section,.connect-section{padding-left:1rem;padding-right:1rem}
+  .team-grid{grid-template-columns:1fr}
+  .connect-person{flex-direction:column;gap:.2rem}
+  .connect-person .name,.connect-person .role{min-width:auto;text-align:center}
+  .connect-actions{margin-top:2rem;flex-direction:column;gap:.8rem}
+}
+
+
+/* ── MPC CUSTODY REPORT CONTENT (extends institutional report system) ── */
+.section{padding:0 0 3rem;border-bottom:none}
+.section-label{font-family:var(--mono);font-size:.6rem;letter-spacing:.2em;text-transform:uppercase;color:var(--text-muted);margin-bottom:10px;display:flex;align-items:center;gap:10px}
+.section-label::before{content:'';width:20px;height:1px;background:var(--text-muted);display:inline-block;flex-shrink:0}
+.section-title{font-family:var(--serif);font-size:clamp(1.5rem,2.8vw,1.76rem);font-weight:600;line-height:1.22;letter-spacing:-.018em;color:var(--navy);margin-bottom:1.25rem}
+.section p{font-size:1rem;line-height:1.68;color:var(--text-body);margin-bottom:1.3em;max-width:none}
+.section p:last-child{margin-bottom:0}
+.hero-body p{font-size:1rem;line-height:1.68;color:var(--text-body)}
+.alert-bar{background:var(--red);color:#fff;padding:16px 24px;margin:28px 0;font-size:.9rem;font-weight:500;line-height:1.6;border-radius:0}
+.audience-block{background:var(--surface);border:1px solid var(--border);padding:24px 28px;margin:28px 0}
+.audience-block .audience-title{font-family:var(--mono);font-size:.62rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:12px}
+.audience-block p{font-size:.9rem;line-height:1.68;color:var(--text-body);margin-bottom:.6rem}
+.methodology{font-family:var(--mono);font-size:.65rem;color:var(--text-muted);line-height:1.6;margin-top:1.2rem;padding-top:.8rem;border-top:1px solid var(--border)}
+.table-wrapper{margin:28px 0 36px;overflow-x:auto;border:1px solid var(--border)}
+.table-caption{font-family:var(--mono);font-size:.62rem;letter-spacing:.12em;text-transform:uppercase;color:var(--navy);margin-bottom:10px;display:block;font-weight:500}
+.data-table{width:100%;border-collapse:collapse;font-size:.84rem;line-height:1.5}
+.data-table thead{background:var(--header-tint)}
+.data-table thead th{font-family:var(--mono);font-size:.72rem;letter-spacing:.06em;text-transform:uppercase;font-weight:700;padding:10px 13px;text-align:left;color:var(--text-header);border-bottom:1px solid var(--border-accent);white-space:nowrap;background:var(--header-tint)}
+.data-table tbody tr{border-bottom:1px solid var(--border)}
+.data-table tbody tr:nth-child(even){background:var(--surface-row)}
+.data-table tbody tr:hover{background:var(--navy-soft)}
+.data-table tbody td{padding:9px 13px;vertical-align:top;color:var(--text);font-size:.84rem;line-height:1.52}
+.data-table .cell-red{color:var(--red);font-weight:600}
+.data-table .cell-green{color:var(--green);font-weight:600}
+.data-table .cell-amber{color:#7B5E2A;font-weight:600}
+.risk-tag{display:inline-block;font-family:var(--mono);font-size:.68rem;font-weight:600;letter-spacing:.03em;text-transform:uppercase;padding:3px 8px;white-space:nowrap}
+.risk-critical{background:var(--red-medium);color:var(--red);border:1px solid rgba(141,46,46,.2)}
+.risk-high{background:rgba(123,94,42,.1);color:#7B5E2A;border:1px solid rgba(123,94,42,.2)}
+.risk-green{background:var(--green-medium);color:var(--green);border:1px solid rgba(47,94,82,.2)}
+.pq-badge{display:inline-block;font-family:var(--mono);font-size:.68rem;font-weight:500;padding:2px 6px}
+.pq-badge.not-safe{background:var(--red-medium);color:var(--red)}
+.pq-badge.impossible{background:var(--red);color:#fff}
+.pq-badge.supported{background:var(--green-medium);color:var(--green)}
+.pq-badge.possible{background:rgba(123,94,42,.1);color:#7B5E2A}
+.table-summary{font-family:var(--mono);font-size:.72rem;font-weight:600;color:var(--red);margin-top:10px;padding:10px 14px;background:var(--red-soft);border-left:3px solid var(--red)}
+.chart-container{margin:28px 0;background:var(--surface);border:1px solid var(--border);padding:24px 20px 16px}
+.chart-title{font-family:var(--mono);font-size:.62rem;letter-spacing:.12em;text-transform:uppercase;color:var(--navy);margin-bottom:16px;font-weight:500}
+.chart-source{font-family:var(--mono);font-size:.62rem;color:var(--text-muted);margin-top:8px}
+.risk-key{background:var(--surface);border:1px solid var(--border);padding:20px 24px;margin:20px 0 24px}
+.risk-key-title{font-family:var(--mono);font-size:.62rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:12px}
+.risk-key-item{display:flex;align-items:flex-start;gap:10px;margin-bottom:6px;font-size:.84rem;line-height:1.5;color:var(--text-body)}
+.expert-quote{border-left:2px solid var(--green);padding:14px 20px;margin:22px 0;background:var(--green-soft)}
+.expert-quote p{font-size:.97rem;font-style:italic;line-height:1.6;color:var(--text-body);margin-bottom:6px}
+.expert-quote footer{font-family:var(--mono);font-size:.62rem;color:var(--text-muted);letter-spacing:.07em;line-height:1.55}
+.expert-quote footer strong{color:var(--navy)}
+.assessment-card{border-left:3px solid var(--navy);background:var(--surface-soft);padding:24px 28px;margin:28px 0}
+.assessment-card .assess-title{font-family:var(--mono);font-size:.62rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--navy);margin-bottom:12px}
+.assessment-card p{font-size:.9rem;line-height:1.68;color:var(--text-body);margin-bottom:.8rem}
+.cta-section{background:var(--navy);padding:36px 40px;margin:36px 0;position:relative;overflow:hidden}
+.cta-section::before{content:'';position:absolute;top:0;right:0;width:40%;height:100%;background:radial-gradient(ellipse at 80% 50%,rgba(47,94,82,.2) 0%,transparent 65%);pointer-events:none}
+.cta-section .cta-title{font-size:1.15rem;font-weight:600;color:#fff;letter-spacing:-.015em;margin-bottom:10px;line-height:1.3;position:relative}
+.cta-section .cta-sub{font-size:.9rem;color:rgba(255,255,255,.65);line-height:1.68;max-width:580px;margin-bottom:24px;position:relative}
+.cta-buttons{display:flex;gap:12px;flex-wrap:wrap;position:relative}
+.cta-btn{display:inline-flex;align-items:center;padding:.7rem 1.4rem;border-radius:4px;font-family:var(--mono);font-size:.75rem;font-weight:600;letter-spacing:.06em;text-decoration:none;cursor:pointer;border:none}
+.cta-primary{background:#fff;color:var(--navy)}
+.cta-secondary{background:transparent;color:#fff;border:1px solid rgba(255,255,255,.35)}
+.timeline-bar{margin:28px 0;background:var(--surface);border:1px solid var(--border);padding:24px 20px;overflow-x:auto;-webkit-overflow-scrolling:touch}
+.tl-track{display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:12px;position:relative;padding-top:8px;min-width:min(100%,640px)}
+.tl-marker{text-align:center;min-width:0}
+.tl-marker .tl-dot{width:10px;height:10px;border-radius:50%;background:var(--navy);margin:10px auto 8px}
+.tl-marker.tl-current .tl-dot{background:var(--green);box-shadow:0 0 0 3px var(--green-medium)}
+.tl-marker .tl-year{font-family:var(--mono);font-size:.62rem;font-weight:600;color:var(--navy)}
+.tl-marker.tl-current .tl-year{color:var(--green)}
+.tl-marker .tl-event{font-size:.68rem;color:var(--text-muted);line-height:1.45;margin-top:4px}
+@media(max-width:700px){
+  .tl-track{grid-template-columns:repeat(3,minmax(88px,1fr));min-width:0}
+  .tl-marker .tl-event{font-size:.64rem}
+}
+.comparison-grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--border-accent);margin:28px 0;border:1px solid var(--border-accent)}
+.comparison-cell{background:var(--surface);padding:24px 22px}
+.comparison-cell h4{font-size:.95rem;font-weight:700;color:var(--navy);margin-bottom:10px}
+.comparison-cell p{font-size:.84rem;color:var(--text-muted);line-height:1.58;margin-bottom:0}
+@media(max-width:700px){.comparison-grid{grid-template-columns:1fr}.cta-section{padding:28px 20px}.cta-buttons{flex-direction:column}}
+.link-muted{color:var(--fg-70);text-decoration:none;border-bottom:none}
+.link-muted:hover{color:var(--fg)}
+.pull-quote:not(:has(p)){font-size:1.25rem;font-style:italic;font-weight:500;line-height:1.55;color:var(--navy);letter-spacing:-.015em;padding-left:28px}
+.pull-quote.pull-quote-green{border-top-color:var(--green)}
+.pull-quote.pull-quote-green:not(:has(p)){color:var(--green)}
+
+</style>
+</head>
+<body>
+
+<!-- ═══ NAVIGATION -->
+{% include navbar.html %}
+
+
+<!-- ═══ COVER -->
+<header class="cover" role="banner">
+<div class="cover-inner">
+  <div class="cover-eyebrow">EternaX Research · Institutional MPC Custody Risk Map · June 2026</div>
+  <h1 class="cover-title">The Post-Quantum Institutional MPC Custody Crisis 2026: 15 Providers, $10 Trillion Protected, Zero Post-Quantum Safe</h1>
+  <p class="cover-subtitle">Why hash-based post-quantum signatures (SPHINCS+ / SLH-DSA, NIST FIPS 205) are mathematically incompatible with MPC custody, and what institutions should do about it</p>
+  <div class="cover-meta">
+    <div class="cover-meta-item"><div class="cover-meta-label">Published</div><div class="cover-meta-value">12 June 2026</div></div>
+    <div class="cover-meta-item"><div class="cover-meta-label">Authors</div><div class="cover-meta-value">Paarrthhh Birla, Co-Founder · Dr. Chen Feng, Chief Scientist · Dariia Porechna, Co-Founder</div></div>
+    <div class="cover-meta-item"><div class="cover-meta-label">Audience</div><div class="cover-meta-value">Custodians · MPC Providers · Risk Committees · Tokenization Teams · Stablecoin Issuers · Institutional Digital Asset Programmes</div></div>
+  </div>
+  <p class="cover-disclaimer">Not investment advice. Based on public evidence from official provider pages, regulator-facing disclosures, official trust centres, and reputable financial reporting accessed 9 June 2026. Independent research from Taurus SA (June 2026), NIST, and Chainalysis. Scale figures labelled "company claim" are not independently audited.</p>
+</div>
+</header>
+
+<!-- ═══ KEY FACTS -->
+<section class="share-panel" aria-label="Key facts summary">
+<div class="content-wide">
+  <span class="share-panel-label">Four facts every custody provider, risk committee, and institutional digital asset team must act on in 2026</span>
+  <div class="share-panel-grid" style="grid-template-columns: repeat(4, 1fr);">
+    <div class="share-panel-cell green-top">
+      <span class="share-panel-num">$10T+</span>
+      <div class="share-panel-desc">Digital assets under MPC custody across 15 reviewed institutional providers.</div>
+    </div>
+    <div class="share-panel-cell green-top">
+      <span class="share-panel-num">15</span>
+      <div class="share-panel-desc">Institutional MPC custody providers reviewed across three market segments.</div>
+    </div>
+    <div class="share-panel-cell red-top">
+      <span class="share-panel-num">0</span>
+      <div class="share-panel-desc">With post-quantum safe custody on any major public chain today.</div>
+    </div>
+    <div class="share-panel-cell red-top">
+      <span class="share-panel-num">2030</span>
+      <div class="share-panel-desc">NIST ECDSA deprecation deadline for classical public-key signatures.</div>
+    </div>
+  </div>
+</div>
+</section>
+
+<main role="main" class="content">
+<section class="section" id="crisis">
+<div class="hero-body">
+<p>MPC custody is the operational backbone of institutional crypto. Fifteen providers collectively protect over $10 trillion in digital assets, serve 550+ million wallets, and process $50 billion+ in monthly notional volume. A separate $32 billion in tokenized real-world assets now sits on classically signed chains. Every one of them relies on classical signature schemes (ECDSA secp256k1, Ed25519) that NIST will deprecate by 2030 and disallow by 2035. The industry's preferred conservative post-quantum replacement, SPHINCS+ (NIST FIPS 205), is mathematically incompatible with MPC. BlackRock BUIDL ($2.5B), JPMorgan Kinexys, Franklin FOBXX, Fidelity, DTCC, Visa, WisdomTree, Ondo ($2B), State Street, Goldman Sachs, and Broadridge ($362B daily) all run on these rails with zero disclosed post-quantum migration roadmaps. This report maps exactly where every provider, every chain, every programme, and every institution stands today.</p>
+</div>
+<blockquote cite="https://eprint.iacr.org/2015/1075" class="expert-quote">
+<p>“Quantum computers will break currently deployed public-key cryptography”</p>
+<footer>— <strong>Michele Mosca</strong>, quantum-safe cryptography researcher. <a href="https://eprint.iacr.org/2015/1075" rel="noopener noreferrer" target="_blank">Cryptology ePrint Archive, 2015</a></footer>
+</blockquote>
+<div class="alert-bar">$2.87 billion stolen through key compromise in 2025. $700M+ in 2026 so far. Attackers are not exploiting code. They are exploiting whoever controls the signing key. A quantum adversary automates this at the mathematical level.</div>
+<div class="audience-block">
+<div class="audience-title">Who Should Read This Report</div>
+<p><strong>If you are an institution using Fireblocks, Copper, BitGo, Anchorage Digital, Cobo, or any MPC custody provider,</strong> this report maps your provider's quantum risk score against 14 peers and names the chains and programmes exposed.</p>
+<p><strong>If you are an MPC custody provider</strong> (Fireblocks, Copper, BitGo, Anchorage Digital, Ripple Custody, Fordefi (Paxos), Cobo, Ceffu, Safeheron, Dfns, Zodia Custody, Qredo, or others), this report scores your PQ readiness, names your institutional clients' exposure, and identifies the structural barrier you face under hash-based PQ migration.</p>
+<p><strong>If you are a VC evaluating custody or infrastructure</strong> (Haun, Dragonfly, Founders Fund, Brevan Howard Digital, a16z, Paradigm), this report quantifies the stranding risk across the MPC custody category and identifies the one structural moat that survives PQ migration.</p>
+<p><strong>If you are a compliance or risk officer at BlackRock, JPMorgan, Franklin Templeton, Goldman Sachs, Fidelity, DTCC, Visa, or any institution building on classically signed chains,</strong> this report frames the NIST 2030/2035 deprecation timeline against your current custody and settlement stack.</p>
+</div>
+</section>
+<!-- ════════ SECTION 2: MARKET ════════ -->
+<section class="section" id="market">
+<div class="section-label">Section 2</div>
+<h2 class="section-title">The Institutional MPC Market</h2>
+<p>Every major institutional custody decision made since 2018 is built on MPC. That installed base is now structurally exposed. The market splits into three segments: large institutional platforms combining MPC with governance, settlement, and regulated trust structures (Fireblocks, Copper, BitGo, Anchorage Digital, Ceffu); bank-grade custody and tokenization infrastructure (Ripple Custody / Metaco, Zodia Custody / Standard Chartered, Fordefi / Paxos, Dfns, Qredo); and hybrid MPC plus HSM or TEE stacks (Safeheron, Liminal, Blockdaemon, Cobo). Across all three segments, the MPC layer improves operational security. Across all three, the final on-chain signature remains classical.</p>
+<div class="table-wrapper">
+<div class="table-caption">Table 1: The Institutional MPC Custody Market at a Glance</div>
+<table class="data-table">
+<thead>
+<tr><th>Provider</th><th>Segment</th><th>Disclosed Scale</th><th>Chains</th><th>Regulatory Status</th><th>Key Institutional Clients</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Fireblocks</strong></td><td>Institutional platform + trust</td><td>$10T+ protected, 550M wallets</td><td>40+</td><td>NYDFS trust charter</td><td>BNY Mellon, ABN AMRO, BNP Paribas, ANZ Bank</td></tr>
+<tr><td><strong>Copper</strong></td><td>Institutional custody + settlement</td><td>$50B+ monthly notional, 1,000+ counterparties</td><td>50+</td><td>SOC 2, ISO 27001</td><td>Brevan Howard, Flow Traders, B2C2, Cumberland</td></tr>
+<tr><td><strong>BitGo</strong></td><td>Custody + wallets + prime</td><td>$104B+ on platform</td><td>Broad</td><td>SD custodian, NY trust, OCC</td><td>Galaxy Digital, Pantera Capital, Hashdex, Bitstamp</td></tr>
+<tr><td><strong>Fordefi (Paxos)</strong></td><td>DeFi-first institutional wallet</td><td>~300 institutional clients, $20B monthly</td><td>90+ chains</td><td>SOC 2 Type 2</td><td>Paxos, Clearstar, Pantera Capital, Figment</td></tr>
+<tr><td><strong>Cobo</strong></td><td>Wallet infra + custody</td><td>$3.8T+ transactions, 200M+ wallets</td><td>80+</td><td>Licensed in 3 jurisdictions</td><td>MetaMask Institutional, Safe{Wallet}, Polymarket, dForce</td></tr>
+<tr><td><strong>Ceffu</strong></td><td>Institutional custody + exchange</td><td>Not publicly disclosed</td><td>Multi-chain</td><td>ISO 27001, SOC 2 Type 2</td><td>Hamilton Lane, Binance institutional clients</td></tr>
+<tr><td><strong>GK8 / Galaxy</strong></td><td>Institutional treasury</td><td>Not publicly disclosed</td><td>Multi-chain</td><td>Galaxy group context</td><td>Galaxy Digital (parent), Goldman Sachs (via Galaxy)</td></tr>
+<tr><td><strong>Liminal</strong></td><td>Custody + wallet infra</td><td>12 countries, 1,200+ tokens</td><td>Multi-chain</td><td>Compliance integrations</td><td>CoinDCX, Hbar Foundation, El Salvador gov</td></tr>
+<tr><td><strong>Safeheron</strong></td><td>MPC self-custody</td><td>$150B+ transferred, 170+ institutions</td><td>EVM-wide</td><td>ISO 27001, SOC 2</td><td>dtcpay, Matrixport, Sinohope, HashKey</td></tr>
+<tr><td><strong>Dfns</strong></td><td>Wallet infra for banks, PSPs</td><td>~1% global stablecoin payments</td><td>Multi-chain</td><td>Not publicly disclosed</td><td>Stripe, Circle, Kraken, MoonPay</td></tr>
+<tr><td><strong>Blockdaemon</strong></td><td>Validator + treasury custody</td><td>Not publicly disclosed</td><td>Multi-chain</td><td>Not publicly disclosed</td><td>CI Global, LHV Bank, Copper (infra partner)</td></tr>
+<tr><td><strong>Anchorage Digital</strong></td><td>Federal crypto bank + custody</td><td>$10T+ transactions, 2,400+ clients</td><td>45+ chains</td><td>OCC federal charter, SOC 2</td><td>Visa, Western Union, Securitize, Aptos</td></tr>
+<tr><td><strong>Zodia Custody (SC)</strong></td><td>Bank-backed custody + SaaS</td><td>75+ assets, 7 offices, ~150 staff</td><td>Multi-chain</td><td>FCA, MiCA, HK, Singapore</td><td>Standard Chartered, Northern Trust, SBI Holdings, Emirates NBD</td></tr>
+<tr><td><strong>Qredo</strong></td><td>Distributed MPC custody</td><td>Not publicly disclosed</td><td>Multi-chain</td><td>Not publicly disclosed</td><td>ConsenSys Mesh, FBG Capital</td></tr>
+<tr><td><strong>Ripple Custody (Metaco)</strong></td><td>Bank-grade custody + tokenization</td><td>Not publicly disclosed</td><td>Multi-chain</td><td>Swiss-regulated, multi-jurisdiction</td><td>HSBC, BNP Paribas, BBVA, DBS</td></tr>
+</tbody>
+</table>
+<div class="table-summary">15 providers. $10T+ combined disclosed custody. 80+ chains covered. Zero post-quantum safe.</div>
+</div>
+<p>MPC is not a feature. It is the foundation. And that foundation has a structural flaw no firmware update can fix.</p>
+<div class="assessment-card">
+<div class="assess-title">Institutions Already on These Rails</div>
+<p>Fireblocks publicly names <strong>ABN AMRO</strong> among its customer stories and references infrastructure protecting $10T+ across 550M wallets. Copper lists <strong>Brevan Howard, Flow Traders, B2C2, Amber, Cumberland, and Fasanara</strong> as counterparties. Anchorage Digital, America's first OCC-chartered crypto bank ($4.2B valuation), custodies assets for <strong>Visa, Western Union, and Securitize</strong> and has processed $10T+ in transactions. Ripple Custody (Metaco) serves some of the deepest Tier 1 bank relationships in the MPC market: <strong>HSBC, BNP Paribas, BBVA, DBS, SocGen Forge, and DekaBank</strong>. BitGo ($104B+ on platform, NYSE: BTGO) custodies for <strong>Galaxy Digital, Pantera Capital, Hashdex, and Bitstamp</strong> across 4,600+ institutional clients. Zodia Custody, founded by <strong>Standard Chartered</strong> and <strong>Northern Trust</strong>, is being absorbed into SC's CIB digital asset division (May 2026) with minority stakes from <strong>SBI Holdings, National Australia Bank, and Emirates NBD</strong> across 7 offices and 75+ assets. Dfns names <strong>Stripe, Circle, Kraken, MoonPay, Apex Group, Paxos, SCB, and Vermont State Bank</strong> as customers. Cobo identifies <strong>MetaMask Institutional</strong> and <strong>Safe{Wallet}</strong> as partners. Safeheron publicly quotes <strong>dtcpay</strong>. Blockdaemon references <strong>CI Global</strong> and <strong>LHV Bank</strong>. Qredo names <strong>ConsenSys Mesh</strong> and <strong>FBG Capital</strong>.</p>
+<p>Beyond the custody providers themselves, $32 billion in tokenized real-world assets now sits on classically signed chains (RWA.xyz, May 2026). Major institutional programmes building directly on these rails: <strong>BlackRock BUIDL</strong> ($2.5B AUM, Ethereum/Solana/Polygon/Avalanche/Arbitrum/Optimism/Aptos/BNB Chain, all secp256k1 or Ed25519), <strong>JPMorgan Kinexys</strong> (settling tokenized Treasuries on public chains, Ethereum-linked), <strong>Franklin Templeton FOBXX/BENJI</strong> (Stellar/Solana, Ed25519), <strong>Goldman Sachs GS DAP</strong> (Canton, deployment-specific classical), <strong>Fidelity tokenized Treasuries</strong> (multi-chain), <strong>DTCC</strong> (multi-chain settlement integration), <strong>Visa stablecoin infrastructure</strong> (Ethereum/Solana, secp256k1/Ed25519), <strong>WisdomTree WTGXX</strong> (surged 759% YoY, Ethereum), <strong>State Street digital custody</strong> (multi-chain), <strong>Broadridge DLT Repo</strong> ($362B daily via Canton), and <strong>Ondo Finance</strong> ($2B combined OUSG/USDY, Ethereum). Zero of these programmes have disclosed a post-quantum migration roadmap. Every one relies on ECDSA or Ed25519 signatures that NIST will deprecate by 2030.</p>
+</div>
+<blockquote cite="https://www.blackrock.com/corporate/literature/article-reprint/larry-fink-rob-goldstein-economist-op-ed-tokenization.pdf" class="expert-quote">
+<p>“tokenisation today is roughly where the internet was in 1996”</p>
+<footer>— <strong>Larry Fink and Rob Goldstein</strong>, BlackRock CEO and COO. <a href="https://www.blackrock.com/corporate/literature/article-reprint/larry-fink-rob-goldstein-economist-op-ed-tokenization.pdf" rel="noopener noreferrer" target="_blank">BlackRock / The Economist, 2025</a></footer>
+</blockquote>
+</section>
+<!-- ════════ SECTION 3: IMPOSSIBILITY ════════ -->
+<section class="section" id="impossibility">
+<div class="section-label">Section 3</div>
+<h2 class="section-title">The Impossibility: $3.4 Billion Stolen Classically. Quantum Makes It Automatic.</h2>
+<blockquote cite="https://arxiv.org/abs/1804.08714" class="expert-quote">
+<p>“With possession of the private key, an attacker virtually owns all of the currency”</p>
+<footer>— <strong>Mordechai Guri</strong>, cybersecurity researcher. <a href="https://arxiv.org/abs/1804.08714" rel="noopener noreferrer" target="_blank">BeatCoin, arXiv, 2018</a></footer>
+</blockquote>
+<!-- 3A: Classical theft -->
+<div class="chart-container">
+<div class="chart-title">Crypto Theft from Key Compromise: The Control Plane Is the Attack Surface</div>
+<svg style="width:100%;max-width:680px;" viewbox="0 0 680 244" xmlns="http://www.w3.org/2000/svg">
+<!-- Bars -->
+<rect fill="#8D2E2E" height="28" opacity="0.6" rx="1" width="312" x="60" y="12"></rect>
+<rect fill="#8D2E2E" height="28" opacity="0.5" rx="1" width="140" x="60" y="50"></rect>
+<rect fill="#8D2E2E" height="28" opacity="0.65" rx="1" width="180" x="60" y="88"></rect>
+<rect fill="#8D2E2E" height="28" rx="1" width="236" x="60" y="126"></rect>
+<rect fill="#8D2E2E" height="28" rx="1" stroke="#8D2E2E" stroke-dasharray="4 2" stroke-width="1" width="96" x="60" y="170"></rect>
+<!-- Labels -->
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="11" font-weight="600" text-anchor="end" x="50" y="31">2022</text>
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="11" font-weight="600" text-anchor="end" x="50" y="69">2023</text>
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="11" font-weight="600" text-anchor="end" x="50" y="107">2024</text>
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="11" font-weight="600" text-anchor="end" x="50" y="145">2025</text>
+<text fill="#8D2E2E" font-family="IBM Plex Sans Condensed" font-size="11" font-weight="700" text-anchor="end" x="50" y="189">2026 YTD</text>
+<!-- Values -->
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="700" x="380" y="31">$3.8B</text>
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="700" x="208" y="69">$1.7B</text>
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="700" x="248" y="107">$2.2B</text>
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="700" x="304" y="145">$2.87B</text>
+<text fill="#8D2E2E" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="700" x="164" y="189">$700M+ (through May)</text>
+<!-- Bybit callout -->
+<rect fill="#fdf2f2" height="22" rx="2" stroke="#8D2E2E" stroke-width="0.5" width="218" x="304" y="130"></rect>
+<text fill="#8D2E2E" font-family="IBM Plex Sans" font-size="9.5" font-weight="500" x="314" y="145">Bybit $1.46B | DPRK 76% of 2025 value stolen</text>
+<!-- 2026 callout -->
+<rect fill="#fdf2f2" height="22" rx="2" stroke="#8D2E2E" stroke-width="0.5" width="276" x="164" y="172"></rect>
+<text fill="#8D2E2E" font-family="IBM Plex Sans" font-size="9.5" font-weight="500" x="174" y="187">Drift $285M + KelpDAO $292M + Q1 $482M (63% phishing)</text>
+<!-- Annotation -->
+<text fill="#5a6178" font-family="IBM Plex Serif" font-size="10" font-style="italic" x="60" y="224">Every incident exploited the same primitive: classical signing keys. Quantum makes the exploit mathematical.</text>
+</svg>
+<div class="chart-source">Sources: TRM Labs 2026 Crypto Crime Report, Chainalysis, PeckShield, Hacken, Global Ledger</div>
+</div>
+<p>The attack pattern has not changed in a decade. Compromise the private key, move the funds. Attackers are not exploiting smart contract code. They are exploiting authority: mint keys, admin multisigs, bridge signers, vault operators, governance councils. The control plane of money. Today, that requires human error. Leaked devices. Phishing. Weak multisigs. Tomorrow, it requires math.</p>
+<blockquote cite="https://www.trmlabs.com/resources/blog/trms-ari-redbord-testifies-before-the-house-committee-on-financial-services-subcommittee-on-national-security" class="expert-quote">
+<p>“bad actors are early adopters of transformative technology”</p>
+<footer>— <strong>Ari Redbord</strong>, Global Head of Policy and Government Affairs, TRM Labs. <a href="https://www.trmlabs.com/resources/blog/trms-ari-redbord-testifies-before-the-house-committee-on-financial-services-subcommittee-on-national-security" rel="noopener noreferrer" target="_blank">Congressional testimony, 2026</a></footer>
+</blockquote>
+<div class="table-wrapper">
+<div class="table-caption">The Control Plane Incident Log: Key Compromise, Not Code Exploits (2025-2026)</div>
+<table class="data-table">
+<thead>
+<tr><th>Date</th><th>Target</th><th>Loss</th><th>Attack Vector</th><th>Signing Scheme Exploited</th></tr>
+</thead>
+<tbody>
+<tr><td>Feb 2025</td><td><strong>Bybit</strong></td><td class="cell-red">$1.46B</td><td>Multisig cold wallet compromise. 3 of 5 signers targeted via phishing + malware.</td><td>secp256k1 ECDSA</td></tr>
+<tr><td>Apr 2026</td><td><strong>Drift Protocol</strong></td><td class="cell-red">$285M</td><td>DPRK operatives infiltrated over months. 31 withdrawals executed in 12 minutes.</td><td>Ed25519 (Solana)</td></tr>
+<tr><td>Apr 2026</td><td><strong>KelpDAO</strong></td><td class="cell-red">$292M</td><td>Bridge validator private key compromised. Fake message released 116,500 rsETH.</td><td>secp256k1 ECDSA (Ethereum)</td></tr>
+<tr><td>Jan 2026</td><td><strong>Step Finance</strong></td><td class="cell-red">$30M</td><td>Compromised private keys. No smart contract bug involved.</td><td>Ed25519 (Solana)</td></tr>
+<tr><td>May 2026</td><td><strong>StablR</strong></td><td class="cell-red">$12.8M</td><td>Unauthorized minting: 8.35M USDR + 4.5M EURR minted in 2 minutes via key control.</td><td>secp256k1 ECDSA</td></tr>
+<tr><td>Feb 2026</td><td><strong>IoTeX (ioTube Bridge)</strong></td><td class="cell-red">$4.4M</td><td>Full control of validator private key. Malicious contract upgrade bypassed signer checks.</td><td>secp256k1 ECDSA (Ethereum)</td></tr>
+<tr><td>Apr 2026</td><td><strong>Volo Protocol</strong></td><td class="cell-red">$3.5M</td><td>Private key compromise. Attacker impersonated vault owner, drained 3 vaults.</td><td>Classical (EVM)</td></tr>
+<tr><td>Q1 2026</td><td><strong>47 incidents (total)</strong></td><td class="cell-red">$482M</td><td>Phishing and social engineering drove $306M (63%) of Q1 2026 losses alone.</td><td>Various classical schemes</td></tr>
+</tbody>
+</table>
+<div class="table-summary">Every incident above exploited the same primitive: classical signing keys (ECDSA secp256k1 or Ed25519). A quantum adversary automates this at the mathematical level.</div>
+</div>
+<p>The pattern is structural. In 2025, adversaries stole $2.87 billion across 150 incidents, with the top 10 accounting for 81% of total losses. In the first four months of 2026, North Korean-linked actors alone were responsible for 76% of all value stolen. $482 million was lost in Q1 2026, with phishing and social engineering driving 63% of those losses. The attack surface is not the smart contract. It is whoever controls the signing key. Whoever controlled the signing key controlled the money. Full stop. MPC distributes key generation and signing, reducing insider and device compromise risk. But on every major public chain, the final signature verified by consensus remains classical ECDSA or Ed25519. A quantum adversary does not need months of social engineering to infiltrate a team. It recovers the private key from the public key visible on-chain after the first transaction. The result is identical. The control plane breaks. The money is gone.</p>
+<blockquote cite="https://ethresear.ch/t/how-to-hard-fork-to-save-most-users-funds-in-a-quantum-emergency/18901" class="expert-quote">
+<p>“if a user has made even one transaction, then the signature of that transaction reveals the public key”</p>
+<footer>— <strong>Vitalik Buterin</strong>, co-founder of Ethereum. <a href="https://ethresear.ch/t/how-to-hard-fork-to-save-most-users-funds-in-a-quantum-emergency/18901" rel="noopener noreferrer" target="_blank">Ethereum Research, 2024</a></footer>
+</blockquote>
+<!-- 3B: SPHINCS+ consensus -->
+<div class="pull-quote">Five independent sources converge on hash-based SPHINCS+ as the conservative institutional post-quantum signature standard: NIST FIPS 205, Circle Arc, Aptos, Ethereum pq.ethereum.org, and Taurus SA.</div>
+<p>NIST published SLH-DSA (FIPS 205) in August 2024 as the stateless hash-based PQ signature standard. Circle's Arc selects SLH-DSA-SHA2-128s for smart-account verification. Aptos proposes the same scheme for post-quantum accounts. Ethereum's PQ working group targets a hash-based direction by 2029. Taurus SA, a regulated HSM-based custodian, independently recommends SPHINCS+ because it relies on hash function security assumptions studied for decades, not on lattice problems less than 20 years old. NSA CNSA 2.0 mandates PQ migration for national security systems by 2027. NIST IR 8547 deprecates ECDSA after 2030 and disallows it after 2035.</p>
+<blockquote cite="https://www.nist.gov/news-events/news/2024/08/nist-releases-first-3-finalized-post-quantum-encryption-standards" class="expert-quote">
+<p>“There is no need to wait for future standards”</p>
+<footer>— <strong>Dustin Moody</strong>, NIST mathematician and PQC standardization lead. <a href="https://www.nist.gov/news-events/news/2024/08/nist-releases-first-3-finalized-post-quantum-encryption-standards" rel="noopener noreferrer" target="_blank">NIST, 2024</a></footer>
+</blockquote>
+<!-- Timeline -->
+<div class="timeline-bar">
+<div class="chart-title">The Deprecation Clock</div>
+<div class="tl-track">
+<div class="tl-marker">
+<div class="tl-year">2024</div>
+<div class="tl-dot"></div>
+<div class="tl-event">NIST publishes FIPS 205 (SLH-DSA)</div>
+</div>
+<div class="tl-marker tl-current">
+<div class="tl-year">Jun 2026</div>
+<div class="tl-dot"></div>
+<div class="tl-event">You are here</div>
+</div>
+<div class="tl-marker">
+<div class="tl-year">2027</div>
+<div class="tl-dot"></div>
+<div class="tl-event">NSA CNSA 2.0 PQ deadline</div>
+</div>
+<div class="tl-marker">
+<div class="tl-year">2029</div>
+<div class="tl-dot"></div>
+<div class="tl-event">Ethereum PQ target</div>
+</div>
+<div class="tl-marker">
+<div class="tl-year">2030</div>
+<div class="tl-dot"></div>
+<div class="tl-event">NIST ECDSA deprecated</div>
+</div>
+<div class="tl-marker">
+<div class="tl-year">2035</div>
+<div class="tl-dot"></div>
+<div class="tl-event">NIST ECDSA disallowed</div>
+</div>
+</div>
+</div>
+<blockquote cite="https://pq.ethereum.org/" class="expert-quote">
+<p>“The work must begin well before the threat arrives”</p>
+<footer>— <strong>Ethereum Foundation Post-Quantum Team</strong>. <a href="https://pq.ethereum.org/" rel="noopener noreferrer" target="_blank">pq.ethereum.org, 2026</a></footer>
+</blockquote>
+<!-- 3C: Impossibility -->
+<p>Taurus SA published in June 2026 that hash-based signatures are "theoretically impossible" under MPC. The mathematical basis is unambiguous. SPHINCS+ signing requires 10,000 to 20,000 SHA-256 compressions per signature. Each compression is approximately 22,000 AND gates in a boolean circuit. To threshold-compute this across 5 institutional MPC parties at 128-bit security: approximately 26 terabytes of communication per signature and 500 to 700 sequential communication rounds. This is 6 to 7 orders of magnitude beyond what institutional custody requires. No optimization trajectory closes this gap. The constraint is not engineering. It is mathematical structure. Hash functions lack the algebraic properties needed to distribute signing computation while preserving completeness, correctness, and privacy.</p>
+<div class="table-wrapper">
+<div class="table-caption">Table 2: PQ Signature Scheme Readiness: HSM vs. MPC (Source: Adapted from Taurus SA, June 2026)</div>
+<table class="data-table">
+<thead>
+<tr><th>PQ Signature Family</th><th>Examples</th><th>Institutional Adoption</th><th>HSM Support</th><th>MPC Support</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Lattice-based</strong></td>
+<td>ML-DSA (Dilithium), FN-DSA (Falcon)</td>
+<td>No major chain commitment</td>
+<td><span class="pq-badge supported">Supported</span></td>
+<td><span class="pq-badge possible">Possible, not production-validated</span></td>
+</tr>
+<tr>
+<td><strong>Hash-based</strong></td>
+<td>SLH-DSA / SPHINCS+, LMS/HSS</td>
+<td>Circle Arc, Aptos, Ethereum direction</td>
+<td><span class="pq-badge supported">Supported</span></td>
+<td><span class="pq-badge impossible">Theoretically impossible</span></td>
+</tr>
+<tr>
+<td><strong>Multivariate</strong></td>
+<td>MAYO, QR-UOV, SNOVA, UOV</td>
+<td>No standard yet</td>
+<td><span class="pq-badge supported">Supported</span></td>
+<td><span class="pq-badge possible">Most MPC-friendly, not ready</span></td>
+</tr>
+<tr>
+<td><strong>MPC-in-the-head</strong></td>
+<td>MQOM, SDitH, AIMer</td>
+<td>No standard yet</td>
+<td><span class="pq-badge supported">Supported</span></td>
+<td><span class="pq-badge possible">Not MPC-friendly, needs research</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+<p>The industry's preferred post-quantum signature category, hash-based schemes (SPHINCS+ / SLH-DSA, NIST FIPS 205), cannot work with the industry's preferred custody model. This is not a SPHINCS+-specific limitation. It applies to the entire hash-based signature family. Hash functions lack the algebraic properties required to distribute signing computation while preserving completeness, correctness, and privacy. Every institution that chose MPC faces a binary path. Path A: abandon MPC, switch to HSM-only custody, accept single-point-of-failure risk, re-architect, re-certify. Path B: adopt lattice-based PQ via threshold protocols that are 2025-2026 vintage, unvalidated for production, and carry security assumptions less than 20 years old. Neither path delivers hash-based PQ security with distributed key management.</p>
+<div class="pull-quote">Unless the custody key and the on-chain PQ authentication key are not the same scheme.</div>
+</section>
+<!-- ════════ SECTION 4: MAP ════════ -->
+<section class="section" id="map">
+<div class="section-label">Section 4</div>
+<h2 class="section-title">Where Every Provider and Every Chain Stands</h2>
+<p>No reviewed MPC custody provider qualifies below High Quantum Risk. The best firms have better migration starting points. None have solved the problem.</p>
+<blockquote cite="https://www.prnewswire.com/news-releases/silence-laboratories-launches-first-quantum-safe-vault-for-digital-asset-custody-302755724.html" class="expert-quote">
+<p>“signature schemes that were not built to withstand quantum threats”</p>
+<footer>— <strong>Andrei Bytes</strong>, Co-Founder and CTO, Silence Laboratories. <a href="https://www.prnewswire.com/news-releases/silence-laboratories-launches-first-quantum-safe-vault-for-digital-asset-custody-302755724.html" rel="noopener noreferrer" target="_blank">PR Newswire / Silence Laboratories, 2026</a></footer>
+</blockquote>
+<div class="risk-key">
+<div class="risk-key-title">Quantum Risk Scoring Key</div>
+<div class="risk-key-item"><span class="risk-tag risk-critical">Highly Critical</span> No public PQ pathway. No cryptographic agility. Migration requires full re-architecture.</div>
+<div class="risk-key-item"><span class="risk-tag risk-critical">Critical</span> Strong MPC today. No public PQ controls. Migration likely painful and multi-year.</div>
+<div class="risk-key-item"><span class="risk-tag risk-high">High</span> API or AA flexibility may help migration. Still fully classical on-chain. No PQ-native stack.</div>
+<div class="risk-key-item"><span class="risk-tag risk-green">Medium</span> Public hybrid-PQ experimentation underway. <em>No provider in this review reaches this level.</em></div>
+<div class="risk-key-item"><span class="risk-tag risk-green">Low</span> PQ-native production custody support. <em>No provider in this review reaches this level.</em></div>
+</div>
+<div class="table-wrapper">
+<div class="table-caption">Table 3: MPC Custody Quantum Risk Assessment: 15 Providers</div>
+<table class="data-table">
+<thead>
+<tr><th>Provider</th><th>Chain Exposure</th><th>Signature Footprint</th><th>Quantum Risk</th><th>Assessment</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Fireblocks</strong></td><td>EVM, BTC, Solana, tokenization</td><td>secp256k1, Ed25519</td><td><span class="risk-tag risk-high">High</span></td><td>Scale, API breadth, and NYDFS trust structure create migration optionality. Serves ABN AMRO and 550M+ wallets. No PQ-native stack.</td></tr>
+<tr><td><strong>Copper</strong></td><td>EVM, BTC, staking, DeFi</td><td>secp256k1 dominant</td><td><span class="risk-tag risk-critical">Critical</span></td><td>ClearLoop settlement for Brevan Howard, Flow Traders, B2C2, Cumberland, Fasanara. No public PQ pathway.</td></tr>
+<tr><td><strong>BitGo</strong></td><td>Bitcoin-first, broad custody</td><td>secp256k1 ECDSA, Schnorr</td><td><span class="risk-tag risk-critical">Critical</span></td><td>Deepest licensing (SD, NY, OCC). $104B+ on platform. No PQ transition design in reviewed material.</td></tr>
+<tr><td><strong>Fordefi (Paxos)</strong></td><td>EVM, DeFi-heavy</td><td>secp256k1 dominant</td><td><span class="risk-tag risk-high">High</span></td><td>MPC SDK and developer stack improve migration potential. Paxos acquisition adds stablecoin infrastructure depth. DeFi frequency worsens exposure window.</td></tr>
+<tr><td><strong>Cobo</strong></td><td>Broad multichain (80+)</td><td>secp256k1, Ed25519</td><td><span class="risk-tag risk-high">High</span></td><td>Broadest wallet abstraction and TSS depth. Partners: MetaMask Institutional, Safe{Wallet}. $3.8T+ transactions. Still classical on-chain.</td></tr>
+<tr><td><strong>Ceffu</strong></td><td>Exchange-linked multichain</td><td>Chain-native classical</td><td><span class="risk-tag risk-critical">Critical</span></td><td>Institutional MPC language. No PQ roadmap evidence in reviewed material.</td></tr>
+<tr><td><strong>GK8 / Galaxy</strong></td><td>Institutional treasury</td><td>Chain-native classical</td><td><span class="risk-tag risk-critical">Critical</span></td><td>uMPC architecture likely capable. Public evidence incomplete in this review.</td></tr>
+<tr><td><strong>Liminal</strong></td><td>Multi-sig + MPC hybrid</td><td>secp256k1 dominant</td><td><span class="risk-tag risk-critical">Critical</span></td><td>Hybrid MPC+HSM widens operational resilience. Does not solve chain-verifier problem.</td></tr>
+<tr><td><strong>Safeheron</strong></td><td>EVM-wide self-custody</td><td>secp256k1 dominant</td><td><span class="risk-tag risk-high">High</span></td><td>Open-source MPC-TSS posture, strong API surface. Best transparency in the cohort. No PQ-native stack.</td></tr>
+<tr><td><strong>Dfns</strong></td><td>Banking, PSP, stablecoin</td><td>EVM + payment classical</td><td><span class="risk-tag risk-high">High</span></td><td>API-first bank infra. Serves Stripe, Circle, Kraken, MoonPay, Apex Group, Paxos, SCB. ~1% global stablecoin payments settle through Dfns. No PQ-native stack.</td></tr>
+<tr><td><strong>Blockdaemon</strong></td><td>Custody + validators</td><td>Chain-native classical</td><td><span class="risk-tag risk-critical">Critical</span></td><td>Biggest hidden quantum debt sits in validator and staking key operations, not wallet signing.</td></tr>
+<tr><td><strong>Anchorage Digital</strong></td><td>EVM, BTC, Solana, stablecoin issuance</td><td>secp256k1, Ed25519</td><td><span class="risk-tag risk-high">High</span></td><td>OCC federal charter and $10T+ transactions create strongest regulatory positioning. MPC + secure enclave architecture. Stablecoin issuance (USDGO, USAT via Tether) adds exposure surface. No PQ-native stack.</td></tr>
+<tr><td><strong>Zodia Custody (SC)</strong></td><td>EVM, BTC, stablecoin custody</td><td>secp256k1, Ed25519</td><td><span class="risk-tag risk-high">High</span></td><td>Standard Chartered CIB absorption (May 2026) gives GSIB-scale migration resources. FCA, MiCA, HK, Singapore licensed. Zodia Switch with LMAX. No PQ-native stack. Bank backing creates strongest migration optionality in the cohort.</td></tr>
+<tr><td><strong>Qredo</strong></td><td>Distributed MPC custody</td><td>Chain-native classical</td><td><span class="risk-tag risk-high">High</span></td><td>dMPC architecture is flexible. No PQ verifier layer. Middleware ends before the chain verifier.</td></tr>
+<tr><td><strong>Ripple Custody (Metaco)</strong></td><td>Bank treasury, tokenization</td><td>Chain-native classical</td><td><span class="risk-tag risk-critical">Critical</span></td><td>Deepest Tier 1 bank client base (HSBC, BNP Paribas, BBVA, DBS). Harmonize platform is bank-grade. No PQ verifier layer. Bank clients inherit full chain-level quantum exposure.</td></tr>
+</tbody>
+</table>
+<div class="table-summary">7 providers at Critical Quantum Risk. 8 providers at High Quantum Risk. Zero at Medium, Low, or PQ-safe.</div>
+</div>
+<div class="table-wrapper">
+<div class="table-caption">Table 4: Chain-Level PQ Failure Map: 16 Networks, Zero PQ-Safe</div>
+<table class="data-table">
+<thead>
+<tr><th>Chain</th><th>Dominant Signing</th><th>PQ Status</th><th>Quantum Failure Mode</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Ethereum</strong></td><td>secp256k1 ECDSA</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Private key recovery from public key. EOA signature forgery. BLS consensus also exposed. <em>Hosts majority of $32B tokenized RWA value. BlackRock BUIDL ($2.5B), JPMorgan Kinexys, WisdomTree, Visa, Ondo ($2B), Circle USDC, Securitize.</em></td></tr>
+<tr><td><strong>Solana</strong></td><td>Ed25519</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Transaction signing key recovery. All three verification programs remain classical. <em>Franklin FOBXX migrated here. Visa stablecoin pilot. 163,000 RWA holders. Drift Protocol hacked $285M Apr 2026.</em></td></tr>
+<tr><td><strong>Canton</strong></td><td>Deployment-specific</td><td><span class="pq-badge not-safe">Not PQ-native</span></td><td>Greater migration flexibility than public L1s. Not PQ-native in reviewed evidence. <em>Goldman Sachs GS DAP, Broadridge $362B daily DLT Repo.</em></td></tr>
+<tr><td><strong>Stellar</strong></td><td>Ed25519</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Classical account key failure. Direct private key recovery. <em>Franklin FOBXX original chain (launched 2021). Circle USDC. Among earliest institutional tokenized fund rails.</em></td></tr>
+<tr><td><strong>Bitcoin</strong></td><td>secp256k1 ECDSA + Schnorr</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Public key exposed at spend time. Signature forgery on any UTXO with visible public key. <em>Fidelity, MicroStrategy, Coinbase Custody, BitGo primary chain.</em></td></tr>
+<tr><td><strong>Base</strong></td><td>secp256k1 (EVM)</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Inherits full Ethereum EOA exposure. <em>Coinbase institutional settlement layer.</em></td></tr>
+<tr><td><strong>Polygon</strong></td><td>secp256k1 (EVM)</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Inherits full Ethereum EOA exposure. <em>Franklin FOBXX secondary chain.</em></td></tr>
+<tr><td><strong>Arbitrum</strong></td><td>secp256k1 (EVM)</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Inherits full Ethereum EOA exposure. <em>KelpDAO hacked $292M Apr 2026 via bridge signer.</em></td></tr>
+<tr><td><strong>Avalanche C-Chain</strong></td><td>secp256k1 (EVM)</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Inherits full Ethereum EOA exposure.</td></tr>
+<tr><td><strong>BNB Chain</strong></td><td>secp256k1 (EVM)</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Inherits full Ethereum EOA exposure.</td></tr>
+<tr><td><strong>Cosmos</strong></td><td>secp256k1 + ed25519</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>User key and validator key forgery. Dual exposure surface. <em>dYdX, Injective, Osmosis ecosystems.</em></td></tr>
+<tr><td><strong>Sui</strong></td><td>Ed25519, secp256k1, secp256r1</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>All three signature schemes classical. zkLogin wrappers do not change underlying crypto.</td></tr>
+<tr><td><strong>Aptos</strong></td><td>Ed25519 + multisig</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Classical account-signing failure. PQ proposal exists but not deployed.</td></tr>
+<tr><td><strong>Starknet</strong></td><td>Stark-curve signature</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Account-validation layer forgery. Custom account logic helps flexibility, not safety.</td></tr>
+<tr><td><strong>Hedera</strong></td><td>Ed25519 + secp256k1</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Account key compromise. Transaction forgery across both key types.</td></tr>
+<tr><td><strong>XRP Ledger</strong></td><td>secp256k1 + Ed25519</td><td><span class="pq-badge not-safe">Not PQ-safe</span></td><td>Account key and signer-list failure across both key models.</td></tr>
+</tbody>
+</table>
+<div class="table-summary">16 networks reviewed. 16 rely on classical signatures. 16 fail under a cryptographically relevant quantum adversary. 10+ major institutional programmes (BlackRock, JPMorgan, Franklin, Goldman, Fidelity, DTCC, Visa, WisdomTree, State Street, Broadridge) build on these rails with zero disclosed PQ migration roadmaps.</div> </div>
+<p>The breakpoint is structurally identical across all chains. Once consensus verification depends on a classical signature, MPC does not protect the chain-facing layer. For hash-based PQ signatures with MPC custody, even account abstraction and custom verifier contracts are insufficient because the threshold computation itself is impossible.</p>
+</section>
+<!-- ════════ SECTION 5: SOLUTION ════════ -->
+<section class="section" id="solution">
+<div class="section-label">Section 5</div>
+<h2 class="section-title">One Architecture Survives</h2>
+<p>Every MPC custody provider in this report faces the same structural dead end. Two paths exist. Both fail. One chain offers a third.</p>
+<!-- The Three Paths Diagram -->
+<div class="chart-container" style="padding:28px 20px 20px;">
+<div class="chart-title">The Industry's Dead End: Two Paths Fail. One Chain Resolves.</div>
+<svg style="width:100%;max-width:700px;" viewbox="0 0 700 320" xmlns="http://www.w3.org/2000/svg">
+<!-- Path A -->
+<rect fill="#fdf2f2" height="88" rx="2" stroke="#8D2E2E" stroke-width="1.5" width="200" x="20" y="16"></rect>
+<text fill="#8D2E2E" font-family="IBM Plex Sans Condensed" font-size="10" font-weight="700" letter-spacing="0.08em" text-anchor="middle" x="120" y="38">PATH A</text>
+<text fill="#283771" font-family="IBM Plex Sans" font-size="11" font-weight="600" text-anchor="middle" x="120" y="56">Abandon MPC</text>
+<text fill="#5a6178" font-family="IBM Plex Sans" font-size="9" text-anchor="middle" x="120" y="70">Switch to HSM-only custody</text>
+<text fill="#5a6178" font-family="IBM Plex Sans" font-size="9" text-anchor="middle" x="120" y="82">Single point of failure</text>
+<text fill="#8D2E2E" font-family="IBM Plex Sans" font-size="9" font-weight="600" text-anchor="middle" x="120" y="94">Loses distributed trust</text>
+<!-- Path B -->
+<rect fill="#fdf2f2" height="88" rx="2" stroke="#8D2E2E" stroke-width="1.5" width="200" x="250" y="16"></rect>
+<text fill="#8D2E2E" font-family="IBM Plex Sans Condensed" font-size="10" font-weight="700" letter-spacing="0.08em" text-anchor="middle" x="350" y="38">PATH B</text>
+<text fill="#283771" font-family="IBM Plex Sans" font-size="11" font-weight="600" text-anchor="middle" x="350" y="56">Lattice-only MPC</text>
+<text fill="#5a6178" font-family="IBM Plex Sans" font-size="9" text-anchor="middle" x="350" y="70">ML-DSA threshold (unproven)</text>
+<text fill="#5a6178" font-family="IBM Plex Sans" font-size="9" text-anchor="middle" x="350" y="82">Assumptions &lt;20 years old</text>
+<text fill="#8D2E2E" font-family="IBM Plex Sans" font-size="9" font-weight="600" text-anchor="middle" x="350" y="94">Loses conservative PQ security</text>
+<!-- Path C: EternaX -->
+<rect fill="#f0f7f5" height="88" rx="2" stroke="#2F5E52" stroke-width="2" width="200" x="480" y="16"></rect>
+<text fill="#2F5E52" font-family="IBM Plex Sans Condensed" font-size="10" font-weight="700" letter-spacing="0.08em" text-anchor="middle" x="580" y="38">ETERNAX</text>
+<text fill="#283771" font-family="IBM Plex Sans" font-size="11" font-weight="600" text-anchor="middle" x="580" y="56">MPC + SPHINCS+</text>
+<text fill="#5a6178" font-family="IBM Plex Sans" font-size="9" text-anchor="middle" x="580" y="70">Custody key: algebraic, MPC-native</text>
+<text fill="#5a6178" font-family="IBM Plex Sans" font-size="9" text-anchor="middle" x="580" y="82">PQ auth: SPHINCS+ (NIST FIPS 205)</text>
+<text fill="#2F5E52" font-family="IBM Plex Sans" font-size="9" font-weight="600" text-anchor="middle" x="580" y="94">Both properties preserved</text>
+<!-- Arrows down -->
+<line marker-end="url(#arrowRed)" stroke="#8D2E2E" stroke-width="1.5" x1="120" x2="120" y1="104" y2="140"></line>
+<line marker-end="url(#arrowRed)" stroke="#8D2E2E" stroke-width="1.5" x1="350" x2="350" y1="104" y2="140"></line>
+<line marker-end="url(#arrowGreen)" stroke="#2F5E52" stroke-width="1.5" x1="580" x2="580" y1="104" y2="140"></line>
+<!-- Result boxes -->
+<rect fill="#8D2E2E" height="36" rx="2" width="200" x="20" y="144"></rect>
+<text fill="#fff" font-family="IBM Plex Sans Condensed" font-size="10" font-weight="600" letter-spacing="0.04em" text-anchor="middle" x="120" y="166">DEAD END</text>
+<rect fill="#8D2E2E" height="36" rx="2" width="200" x="250" y="144"></rect>
+<text fill="#fff" font-family="IBM Plex Sans Condensed" font-size="10" font-weight="600" letter-spacing="0.04em" text-anchor="middle" x="350" y="166">UNPROVEN / WEAKER</text>
+<rect fill="#2F5E52" height="36" rx="2" width="200" x="480" y="144"></rect>
+<text fill="#fff" font-family="IBM Plex Sans Condensed" font-size="10" font-weight="600" letter-spacing="0.04em" text-anchor="middle" x="580" y="166">PRODUCTION-READY</text>
+<!-- MPC + SPHINCS+ Compatibility Grid -->
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="11" font-weight="700" letter-spacing="0.06em" text-anchor="middle" x="350" y="210">MPC CUSTODY + SPHINCS+ COMPATIBILITY</text>
+<!-- Grid headers -->
+<text fill="#5a6178" font-family="IBM Plex Sans" font-size="9" font-weight="600" text-anchor="end" x="200" y="236">Ethereum</text>
+<text fill="#5a6178" font-family="IBM Plex Sans" font-size="9" font-weight="600" text-anchor="end" x="200" y="254">Bitcoin</text>
+<text fill="#5a6178" font-family="IBM Plex Sans" font-size="9" font-weight="600" text-anchor="end" x="200" y="272">Solana</text>
+<text fill="#5a6178" font-family="IBM Plex Sans" font-size="9" font-weight="600" text-anchor="end" x="200" y="290">Canton</text>
+<text fill="#2F5E52" font-family="IBM Plex Sans" font-size="9" font-weight="600" text-anchor="end" x="200" y="308">EternaX</text>
+<!-- Impossible markers -->
+<rect fill="#8D2E2E" height="14" rx="2" width="100" x="216" y="226"></rect>
+<text fill="#fff" font-family="IBM Plex Mono" font-size="8" font-weight="600" text-anchor="middle" x="266" y="236">IMPOSSIBLE</text>
+<rect fill="#8D2E2E" height="14" rx="2" width="100" x="216" y="244"></rect>
+<text fill="#fff" font-family="IBM Plex Mono" font-size="8" font-weight="600" text-anchor="middle" x="266" y="254">IMPOSSIBLE</text>
+<rect fill="#8D2E2E" height="14" rx="2" width="100" x="216" y="262"></rect>
+<text fill="#fff" font-family="IBM Plex Mono" font-size="8" font-weight="600" text-anchor="middle" x="266" y="272">IMPOSSIBLE</text>
+<rect fill="#8D2E2E" height="14" rx="2" width="100" x="216" y="280"></rect>
+<text fill="#fff" font-family="IBM Plex Mono" font-size="8" font-weight="600" text-anchor="middle" x="266" y="290">IMPOSSIBLE</text>
+<rect fill="#2F5E52" height="14" rx="2" width="100" x="216" y="298"></rect>
+<text fill="#fff" font-family="IBM Plex Mono" font-size="8" font-weight="700" text-anchor="middle" x="266" y="308">SUPPORTED</text>
+<!-- Arrow markers -->
+<defs>
+<marker id="arrowRed" markerheight="8" markerwidth="8" orient="auto" refx="6" refy="4"><path d="M0,0 L8,4 L0,8" fill="#8D2E2E"></path></marker>
+<marker id="arrowGreen" markerheight="8" markerwidth="8" orient="auto" refx="6" refy="4"><path d="M0,0 L8,4 L0,8" fill="#2F5E52"></path></marker>
+</defs>
+</svg>
+</div>
+<!-- TPS Loss Chart -->
+<div class="chart-container">
+<div class="chart-title">TPS Loss Under Hash-Based Post-Quantum Signature Migration</div>
+<svg style="width:100%;max-width:680px;" viewbox="0 0 680 210" xmlns="http://www.w3.org/2000/svg">
+<!-- EternaX -->
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="600" text-anchor="end" x="88" y="28">EternaX</text>
+<rect fill="#2F5E52" height="24" rx="1" width="12" x="96" y="14"></rect>
+<text fill="#2F5E52" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="700" x="116" y="31">~2%</text>
+<!-- Ethereum -->
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="600" text-anchor="end" x="88" y="70">Ethereum</text>
+<rect fill="#8D2E2E" height="24" rx="1" width="420" x="96" y="56"></rect>
+<text fill="#8D2E2E" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="700" x="524" y="73">~84%</text>
+<!-- Canton -->
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="600" text-anchor="end" x="88" y="112">Canton</text>
+<rect fill="#8D2E2E" height="24" rx="1" width="440" x="96" y="98"></rect>
+<text fill="#8D2E2E" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="700" x="544" y="115">~88%</text>
+<!-- Solana -->
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="600" text-anchor="end" x="88" y="154">Solana</text>
+<rect fill="#8D2E2E" height="24" rx="1" width="450" x="96" y="140"></rect>
+<text fill="#8D2E2E" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="700" x="554" y="157">~90%</text>
+<!-- Stellar -->
+<text fill="#283771" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="600" text-anchor="end" x="88" y="196">Stellar</text>
+<rect fill="#8D2E2E" height="24" rx="1" width="450" x="96" y="182"></rect>
+<text fill="#8D2E2E" font-family="IBM Plex Sans Condensed" font-size="12" font-weight="700" x="554" y="199">~90%</text>
+</svg>
+</div>
+<!-- What custodians get -->
+<div class="assessment-card" style="border-left-color:#2F5E52;">
+<div class="assess-title" style="color:#2F5E52;">What Every MPC Custodian Gets on EternaX</div>
+<p><strong>You change nothing about your operating model.</strong> Your MPC infrastructure maps directly onto EternaX. You run your distributed authorization quorum exactly as you do today. Same key management. Same policy engine. Same approval workflows. Same HSM boundaries. Same regulatory licenses. The chain accepts your MPC authorization output through one pathway and handles hash-based PQ verification through a separate pathway. You never threshold-compute a hash-based signature. The impossibility result is never violated.</p>
+<p><strong>Hash-based PQ compliance without thresholding hash-based signatures.</strong> The chain separates the custody key (algebraic, MPC-native, threshold-friendly) from the PQ authentication key (SPHINCS+ / SLH-DSA, NIST FIPS 205, hash-based, hardware-boundary). Both compose per transaction at the protocol level. The Taurus SA impossibility is conceded and routed around by design.</p>
+<p><strong>160 bytes permanent, not 7,856.</strong> The on-chain settlement record is 160 bytes per transaction (SILMARILS: <a href="https://arxiv.org/abs/2605.03230" rel="noopener noreferrer" target="_blank" style="color:#2F5E52;">arXiv:2605.03230</a>). SPHINCS+-128s on any other chain is 7,856 bytes, 49 times larger, permanently on-chain, on every transaction.</p>
+<p><strong>~2% TPS loss, not ~90%.</strong> EternaX retains 50,000 to 200,000 TPS under PQ operations with 20-50ms soft finality and 400-520ms hard finality. Solana loses ~90%. Ethereum loses ~84%. Canton loses ~88%.</p>
+<p><strong>First-mover advantage.</strong> The first custody provider to integrate with EternaX offers something no competitor on any other chain can match: hash-based PQ-safe MPC custody with the most conservative NIST-approved post-quantum signature standard. That is a new product line, a new fee tier, and a new mandate-winning capability.</p>
+</div>
+<div class="assessment-card" >
+<div class="assess-title" >What Institutions Get on EternaX</div>
+<p><strong>Same custody provider. Same MPC. Hash-based PQ-safe.</strong> You do not switch custody providers. You do not migrate keys. You do not rebuild compliance frameworks. Your existing custody provider (Fireblocks, Copper, BitGo, Anchorage Digital, Zodia Custody, or any MPC provider) runs their MPC exactly as they do today, on the only chain where hash-based post-quantum compliance is mathematically possible.</p>
+<p><strong>SPHINCS+-compliant settlement from day one.</strong> Every asset issued, transferred, or settled on EternaX carries hash-based post-quantum authentication (SPHINCS+ / SLH-DSA, NIST FIPS 205) at the protocol level. No migration debt (<a href="https://eternax.ai/post-quantum-cryptography-risk-framework-for-institutions.html" rel="noopener noreferrer" target="_blank" >see: Cryptographic Migration Debt framework, $57B-$135B institutional exposure</a>). No retrofit. No deadline pressure. Your NIST 2030/2035 compliance obligation is resolved at the infrastructure layer.</p>
+<p><strong>Fiduciary defensibility.</strong> When your board, your regulator, or your auditor asks whether your digital asset custody is post-quantum safe, you have a verifiable answer: hash-based PQ-safe MPC custody, with the most conservative NIST-approved signature standard, on the only chain where that combination is architecturally possible. That is a fiduciary position, not a technology bet.</p>
+</div>
+<div class="table-wrapper">
+<div class="table-caption">Table 5: EternaX vs. Incumbent Chains Under Hash-Based PQ Migration</div>
+<table class="data-table">
+<thead>
+<tr><th>Metric</th><th style="background:#2F5E52;">EternaX</th><th>Ethereum</th><th>Solana</th><th>Canton</th><th>Stellar</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Hash-based PQ + MPC custody</strong></td><td class="cell-green">Supported</td><td class="cell-red">Impossible</td><td class="cell-red">Impossible</td><td class="cell-red">Impossible</td><td class="cell-red">Impossible</td></tr>
+<tr><td><strong>TPS loss under hash-based PQ</strong></td><td class="cell-green">~2%</td><td class="cell-red">~84%</td><td class="cell-red">~90%</td><td class="cell-red">~88%</td><td class="cell-red">~90%</td></tr>
+<tr><td><strong>PQ signature standard</strong></td><td class="cell-green">SPHINCS+ (NIST FIPS 205)</td><td>SPHINCS+ (target)</td><td>TBD</td><td>TBD</td><td>TBD</td></tr>
+<tr><td><strong>TPS range</strong></td><td class="cell-green">50,000-200,000</td><td>~15-30</td><td>~4,000 (post-PQ)</td><td>~600 (post-PQ)</td><td>~100 (post-PQ)</td></tr>
+<tr><td><strong>Soft finality</strong></td><td class="cell-green">20-50ms</td><td>~12s</td><td>~400ms</td><td>Variable</td><td>~5s</td></tr>
+<tr><td><strong>Hard finality</strong></td><td class="cell-green">400-520ms</td><td>~15 min</td><td>~12.8s</td><td>Variable</td><td>~5s</td></tr>
+</tbody>
+</table>
+</div>
+<div class="assessment-card" style="border-left-color:var(--border);">
+<div class="assess-title">Further Research from EternaX Labs</div>
+<p><a href="https://eternax.ai/post-quantum-cryptography-risk-framework-for-institutions.html" rel="noopener noreferrer" target="_blank" >Cryptographic Migration Debt: The Post-Quantum Risk Framework for Institutional Digital Assets</a><br/>$57B-$135B first-order migration debt across 9 named institutional programmes. The three-plane framework (Asset, Control, Privacy) for boards and risk committees.</p>
+<p><a href="https://eternax.ai/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html" rel="noopener noreferrer" target="_blank" >Post-Quantum Exposure Map 2026</a><br/>20+ institutions, 30+ tokenized products, 11 networks, zero PQ migrations found. The institutional PQ exposure landscape.</p>
+<p><a href="https://eternax.ai/blogs/silmarils-post-quantum-authentication-without-size-tax/index.html" rel="noopener noreferrer" target="_blank" >SILMARILS: Compact Post-Quantum Authentication for Blockchain Systems</a><br/>How decomposing the four jobs bundled into a transaction signature makes post-quantum settlement practical without a permanent per-transaction size tax. 160-byte designated-verifier signatures with SPHINCS+ anchoring.</p>
+<p><a href="https://arxiv.org/abs/2605.03230" rel="noopener noreferrer" target="_blank" >SILMARILS Paper (arXiv:2605.03230)</a><br/>Khodaiemehr, Bagheri, Feng, Porechna. Formal ROM, QROM, and information-theoretic analysis. The cryptographic foundation of EternaX's authentication layer.</p>
+<p><a href="https://eternax.ai/why-eternax.html" rel="noopener noreferrer" target="_blank" >Why EternaX: Institutional Settlement with Privacy, Composability, and PQ-Native Security</a><br/>Three institutional requirements converging: privacy, DeFi composability, post-quantum security. The full product thesis.</p>
+</div>
+<div class="pull-quote">Hash-based PQ-safe MPC custody is mathematically impossible on every chain except one. The fifteen providers mapped in this report cannot deliver it on any chain they currently serve. On EternaX, they can.</div>
+<div class="pull-quote pull-quote-green">EternaX does not replace your custody provider. EternaX is where your custody provider becomes PQ-safe.</div>
+<p>EternaX is not competing for MPC custody market share. EternaX is the settlement layer where MPC custody and hash-based post-quantum compliance (SPHINCS+ / SLH-DSA, NIST FIPS 205) converge. A competing chain would need to design and formally verify a new custody-layer cryptographic construction, redesign transaction validation, implement ephemeral signature propagation and pruning, migrate all existing accounts and state, and secure ecosystem-wide consensus. That is a multi-year protocol redesign, not a firmware update. The fifteen providers in this report do not need to wait for it. The rail exists.</p>
+</section>
+<!-- ════════ SECTION 6: ACTION ════════ -->
+<section class="section" id="action">
+<div class="section-label">Section 6</div>
+<h2 class="section-title">What Institutions Should Do Now</h2>
+<p>Post-quantum custody readiness is not a project with a completion date. It is a governance obligation that starts with three questions.</p>
+<blockquote cite="https://www.nextgov.com/emerging-tech/2023/08/new-post-quantum-cryptography-guidance-offers-first-steps-toward-migration/389595/" class="expert-quote">
+<p>“begin preparing now for migration to post-quantum cryptography”</p>
+<footer>— <strong>Jen Easterly</strong>, former Director, CISA. <a href="https://www.nextgov.com/emerging-tech/2023/08/new-post-quantum-cryptography-guidance-offers-first-steps-toward-migration/389595/" rel="noopener noreferrer" target="_blank">CISA/NSA/NIST guidance coverage, 2023</a></footer>
+</blockquote>
+<div class="assessment-card">
+<div class="assess-title">Three Questions Every Institution Should Ask Their Custody Provider</div>
+<p><strong>Question 1:</strong> Does your post-quantum signature roadmap include hash-based schemes (SLH-DSA / SPHINCS+), or only lattice-based alternatives? If only lattice-based, what is your assessment of the security assumption risk given these algorithms rely on mathematical problems less than 20 years old?</p>
+<p><strong>Question 2:</strong> Can your MPC stack threshold-compute SPHINCS+ signatures? If not, what is your documented alternative for delivering hash-based PQ security with distributed key management?</p>
+<p><strong>Question 3:</strong> What is your compliance plan for the NIST IR 8547 ECDSA deprecation (2030) and disallowance (2035) timeline, and how does your custody architecture adapt when the blockchains you support migrate to PQ signatures?</p>
+</div>
+<blockquote cite="https://industrialcyber.co/cisa/cisa-nsa-nist-factsheet-addresses-migration-to-post-quantum-cryptography-ahead-of-standards-rollout/" class="expert-quote">
+<p>“The key is to be on this journey today and not wait until the last minute”</p>
+<footer>— <strong>Rob Joyce</strong>, former Director of Cybersecurity, NSA. <a href="https://industrialcyber.co/cisa/cisa-nsa-nist-factsheet-addresses-migration-to-post-quantum-cryptography-ahead-of-standards-rollout/" rel="noopener noreferrer" target="_blank">CISA/NSA/NIST guidance coverage, 2023</a></footer>
+</blockquote>
+<p>If the answer to Question 2 is "no" or "we are evaluating," the institution is carrying unmitigated post-quantum custody risk across every chain and every asset under that provider's management. If the answer to Question 1 excludes hash-based schemes, the institution is betting its long-term custody security on lattice assumptions that have not been tested against quantum adversaries in practice. If the answer to Question 3 is "we are monitoring," the institution does not have a plan.</p>
+<div class="assessment-card">
+<div class="assess-title">Where Do You Stand?</div>
+<p><strong>If your custody provider scores Critical Quantum Risk in this report:</strong> Request a written PQ roadmap within 90 days. Document residual risk. Evaluate PQ-native settlement infrastructure for new deployments.</p>
+<p><strong>If your custody provider scores High Quantum Risk:</strong> Request a PQ roadmap. Establish an internal review date aligned with the NIST 2030 deprecation. Begin due diligence on PQ-native chains for pilot settlement.</p>
+<p><strong>If your custody provider is not listed in this report:</strong> The three questions above still apply.</p>
+</div>
+<div class="cta-section">
+<div class="cta-title">Evaluate Post-Quantum Settlement Infrastructure</div>
+<div class="cta-sub">EternaX is the only chain where hash-based PQ-safe MPC custody (SPHINCS+ / SLH-DSA, NIST FIPS 205) is architecturally possible.</div>
+<div class="cta-buttons">
+<a class="cta-btn cta-primary" href="https://eternax.ai">Book an Institutional Pilot Call</a>
+<a class="cta-btn cta-secondary" href="https://eternax.ai/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html">Read the Full PQ Exposure Map</a>
+</div>
+</div>
+<div class="assessment-card">
+<div class="assess-title">For MPC Custody and HSM Providers</div>
+<p>EternaX is a settlement rail, not a custodian. We do not compete with your custody business. We make your custody business hash-based PQ-safe. The chain enforces the post-quantum validity rule. You run the distributed authorization quorum, the policy engine, key recovery, and the customer relationship. Your existing MPC and HSM infrastructure, key-management discipline, and approval workflows map directly onto the rail. You never threshold-compute a hash-based signature. Nothing about the cryptography asks you to leave the operating model you know.</p>
+<p>Integrate with EternaX and offer your clients the only hash-based PQ-safe MPC custody in the market. First mover wins the mandate. No competitor on any other chain can match this claim.</p>
+<p>We are actively working with custody and HSM providers who want to offer hash-based post-quantum custody on the rail. If you are Fireblocks, Copper, BitGo, Anchorage Digital, Ripple Custody, Cobo, Safeheron, Dfns, Zodia Custody, Fordefi (Paxos), Liminal, Blockdaemon, or any MPC provider looking at the hash-based PQ migration barrier described in this report, <strong>we would like to talk.</strong></p>
+<div class="cta-buttons" style="margin-top:12px;">
+<a class="cta-btn cta-primary" href="mailto:paarrthhh.b@eternax.ai">Contact EternaX</a>
+<a class="cta-btn cta-secondary" href="https://eternax.ai/why-eternax.html">Why EternaX</a>
+</div>
+</div>
+<div class="assessment-card" >
+<div class="assess-title" >For Institutions Using MPC Custody</div>
+<p>Ask your custody provider one question: <strong>Can your MPC threshold-compute hash-based post-quantum signatures (SPHINCS+ / SLH-DSA) on any chain you currently support?</strong> The answer is no. On every chain except EternaX, hash-based PQ signatures are mathematically incompatible with MPC threshold computation.</p>
+<p>You do not need to switch custody providers. You do not need to rebuild your operating model. Your existing provider (Fireblocks, Copper, BitGo, Anchorage Digital, Zodia Custody, or any MPC custodian) runs their MPC exactly as they do today on EternaX. The chain handles hash-based PQ verification at the protocol level. Your provider offers you SPHINCS+-compliant PQ-safe custody. No other chain makes this possible. The institutions that demand hash-based PQ-safe custody first will set the terms, win the strongest fiduciary position, and define the standard their competitors must follow.</p>
+<div class="cta-buttons" style="margin-top:12px;">
+<a class="cta-btn cta-primary" href="mailto:paarrthhh.b@eternax.ai">Contact EternaX</a>
+<a class="cta-btn cta-secondary" href="https://eternax.ai/post_quantum_exposure_map_institutional_crypto_tokenized_assets.html">Read the PQ Exposure Map</a>
+</div>
+</div>
+</section>
+<!-- ════════ SECTION 7: FAQ ════════ -->
+<section class="section" id="faq">
+<div class="section-label">Section 7</div>
+<h2 class="section-title">Frequently Asked Questions</h2>
+<details class="faq-item" id="what-is-post-quantum-custody">
+<summary class="faq-q">What is post-quantum custody?</summary>
+<div class="faq-a"><p>Post-quantum custody is digital asset custody infrastructure that remains secure after a cryptographically relevant quantum computer can break today’s classical public-key signatures. The issue is not only wallet security; it is the full custody and settlement stack: ECDSA, Ed25519, Schnorr, key recovery, policy engines, backup encryption, MPC workflows, HSM boundaries, and chain-level signature verification. Institutions using Fireblocks, Copper, BitGo, Anchorage Digital, Cobo, Dfns, Safeheron, Fordefi (Paxos), or similar providers still rely on classical signatures on the underlying chains.</p></div>
+</details>
+<details class="faq-item" id="why-post-quantum-custody-matters">
+<summary class="faq-q">Why does post-quantum custody matter for institutions?</summary>
+<div class="faq-a"><p>Post-quantum custody matters because institutional digital assets are controlled by signatures, not by branding, regulation, or custody policy alone. A quantum adversary that can recover private keys from exposed public keys can bypass the operational controls around those keys. This affects custody wallets, mint keys, bridge validators, tokenized fund administrators, stablecoin issuers, staking operators, treasury systems, and settlement rails. The risk is structural because every major public chain still verifies classical signatures.</p></div>
+</details>
+<details class="faq-item" id="is-mpc-custody-post-quantum-safe">
+<summary class="faq-q">Is MPC custody post-quantum safe?</summary>
+<div class="faq-a"><p>No. MPC custody is not post-quantum safe if the final signature verified by the blockchain is still ECDSA, Ed25519, or Schnorr. MPC distributes signing authority across multiple parties, which improves operational security against theft, insiders, and device compromise. But MPC does not change the chain-visible signature scheme. A quantum adversary attacks the public-key signature layer that consensus verifies, not the internal MPC ceremony used to produce the signature.</p></div>
+</details>
+<details class="faq-item" id="does-mpc-protect-against-shors-algorithm">
+<summary class="faq-q">Does MPC protect against Shor’s algorithm?</summary>
+<div class="faq-a"><p>No. MPC does not protect ECDSA, Ed25519, or Schnorr signatures from Shor’s algorithm. Shor’s algorithm attacks the mathematical hardness assumptions behind elliptic-curve and RSA cryptography. MPC can split control of a private key across parties, but once a public key is exposed on-chain, the underlying classical signature scheme remains vulnerable. This is why MPC custody and post-quantum custody are not the same thing.</p></div>
+</details>
+<details class="faq-item" id="are-fireblocks-copper-bitgo-cobo-post-quantum-safe">
+<summary class="faq-q">Are Fireblocks, Copper, BitGo, Cobo, Dfns, Safeheron, and Fordefi post-quantum safe?</summary>
+<div class="faq-a"><p>No reviewed institutional MPC custody provider is post-quantum safe today. Fireblocks, Copper, BitGo, Anchorage Digital, Ripple Custody, Cobo, Dfns, Safeheron, Fordefi (Paxos), Zodia Custody, Qredo, and similar platforms may offer strong operational controls, but the assets they custody ultimately settle on chains using classical signatures. Unless the underlying chain supports post-quantum verification and the custody architecture can operate with that verification model, the custody stack remains exposed to quantum key recovery.</p></div>
+</details>
+<details class="faq-item" id="can-mpc-threshold-compute-sphincs-signatures">
+<summary class="faq-q">Can MPC threshold-compute SPHINCS+ signatures?</summary>
+<div class="faq-a"><p>No. Threshold SPHINCS+ is not commercially practical for institutional MPC custody because hash-based signatures lack the algebraic structure MPC needs for efficient distributed signing. SPHINCS+ signing requires thousands of hash computations, and threshold-computing those operations across multiple institutional parties creates extreme communication and round-complexity overhead. This is a structural cryptographic barrier, not a simple implementation gap or vendor roadmap issue.</p></div>
+</details>
+<details class="faq-item" id="why-is-sphincs-preferred-for-institutions">
+<summary class="faq-q">Why is SPHINCS+ preferred for conservative institutional post-quantum security?</summary>
+<div class="faq-a"><p>SPHINCS+, standardized by NIST as SLH-DSA in FIPS 205, is preferred by conservative institutions because it is hash-based. Its security relies on hash-function assumptions that have been studied for decades, rather than newer lattice assumptions. That makes SPHINCS+ attractive for critical infrastructure, long-duration assets, settlement systems, tokenized funds, and regulated financial infrastructure where robustness matters more than elegance. The problem is that SPHINCS+ is structurally incompatible with conventional MPC custody.</p></div>
+</details>
+<details class="faq-item" id="mpc-vs-hsm-post-quantum-custody">
+<summary class="faq-q">What is the difference between MPC and HSM custody for post-quantum migration?</summary>
+<div class="faq-a"><p>HSM custody can support post-quantum signature standards such as SPHINCS+ inside a protected hardware boundary, while conventional MPC custody cannot efficiently threshold-compute hash-based SPHINCS+ signatures. The tradeoff is severe: HSMs offer post-quantum algorithm support but concentrate trust in hardware boundaries; MPC distributes trust but struggles with the most conservative hash-based PQ signatures. EternaX resolves this by separating MPC-compatible custody control from post-quantum authentication at the chain level.</p></div>
+</details>
+<details class="faq-item" id="what-is-the-nist-2030-2035-timeline">
+<summary class="faq-q">What is the NIST 2030 and 2035 timeline for classical signatures?</summary>
+<div class="faq-a"><p>The relevant NIST migration timeline signals that classical public-key schemes such as ECDSA, EdDSA, RSA, and related signature systems should be phased out of sensitive systems over the next decade. For digital assets, that matters because Ethereum, Bitcoin, Solana, Polygon, Avalanche, Arbitrum, BNB Chain, Stellar, and most custody systems still depend on classical signatures. Institutions should not wait until the deadline year; custody migrations require years of vendor review, chain support, testing, audits, governance, and counterparty acceptance.</p></div>
+</details>
+<details class="faq-item" id="can-existing-custody-provider-offer-pq-safe-on-eternax">
+<summary class="faq-q">Can my existing custody provider offer PQ-safe custody on EternaX?</summary>
+<div class="faq-a"><p>Yes. EternaX is the only chain where existing MPC custody infrastructure remains functional under hash-based post-quantum migration. Your custody provider (Fireblocks, Copper, BitGo, Anchorage Digital, Zodia Custody, or any MPC provider) runs their distributed authorization quorum exactly as they do today. The chain handles SPHINCS+ (hash-based, NIST FIPS 205) verification at the protocol level. No threshold computation of hash-based signatures is required. Your provider keeps their MPC, their licenses, their policy engine, and your client relationship. You get hash-based PQ-safe custody without switching providers.</p></div>
+</details>
+<details class="faq-item" id="does-eternax-compete-with-mpc-custody-providers">
+<summary class="faq-q">Does EternaX compete with MPC custody providers?</summary>
+<div class="faq-a"><p>No. EternaX is a settlement rail, not a custodian. Custody providers keep their clients, their licenses, their MPC infrastructure, and their operating models. EternaX makes their custody hash-based PQ-safe. The chain provides the architecture where the custody provider's MPC authorization output composes with SPHINCS+ verification at the protocol level. This is analogous to how Ethereum provides the settlement layer and Fireblocks provides the custody layer, except that on EternaX, the custody provider can offer hash-based post-quantum compliance that is mathematically impossible on any other chain.</p></div>
+</details>
+<details class="faq-item" id="which-blockchains-are-post-quantum-safe">
+<summary class="faq-q">Which major blockchains are post-quantum safe today?</summary>
+<div class="faq-a"><p>No major public blockchain is post-quantum safe in production today. Ethereum, Bitcoin, Solana, Polygon, Avalanche, Arbitrum, Optimism, BNB Chain, Stellar, Aptos, Sui, Canton, and similar networks still rely on classical signature verification in their production settlement flows. Some ecosystems are researching post-quantum migration, but research direction is not production protection. Assets remain exposed until the chain, account model, wallet stack, custody layer, and migration path are all post-quantum-ready.</p></div>
+</details>
+<details class="faq-item" id="can-ethereum-bitcoin-solana-migrate-to-sphincs">
+<summary class="faq-q">Can Ethereum, Bitcoin, or Solana migrate to SPHINCS+ without breaking MPC custody?</summary>
+<div class="faq-a"><p>Not cleanly. If a chain simply replaces ECDSA or Ed25519 with SPHINCS+, it may improve post-quantum signature security but can break compatibility with conventional MPC custody. That is because SPHINCS+ is hash-based and not efficiently threshold-computable under standard MPC models. A serious migration must solve both problems together: post-quantum chain verification and institutional distributed custody. Treating them separately creates a new custody bottleneck.</p></div>
+</details>
+<details class="faq-item" id="what-is-pq-safe-custody-vs-pq-safe-settlement">
+<summary class="faq-q">What is the difference between post-quantum custody and post-quantum settlement?</summary>
+<div class="faq-a"><p>Post-quantum custody protects the systems that authorize asset movement; post-quantum settlement protects the chain that validates and finalizes asset movement. Institutions need both. A custody provider can harden devices, approvals, policies, and key storage, but if the blockchain still accepts classical signatures, the final settlement layer remains quantum-exposed. EternaX focuses on post-quantum settlement infrastructure so custody providers can operate on a rail designed for quantum-durable transaction validity from genesis.</p></div>
+</details>
+<details class="faq-item" id="what-is-the-control-plane-risk">
+<summary class="faq-q">What is custody control-plane risk in a post-quantum world?</summary>
+<div class="faq-a"><p>Custody control-plane risk is the risk that the systems controlling authorization are compromised, even if the asset contract itself is not hacked. Today, attackers target laptops, admin consoles, policy engines, signer devices, backups, bridges, validator keys, and multisig quorums. In a post-quantum world, the attacker may not need theft, phishing, malware, or social engineering. If public keys are exposed and signatures are classical, quantum key recovery can convert control-plane risk into mathematical key compromise.</p></div>
+</details>
+<details class="faq-item" id="how-much-crypto-stolen-through-key-compromise">
+<summary class="faq-q">How much crypto has been stolen through private key and signing-control compromise?</summary>
+<div class="faq-a"><p>Billions of dollars have been lost through private key compromise, signer compromise, phishing, malware, multisig failures, bridge validator compromise, and admin-key misuse. The institutional lesson is direct: the control plane of crypto is the signing layer. Smart-contract audits do not protect assets if the keys that authorize movement are compromised. A quantum attacker turns this same pattern into an algorithmic attack by recovering keys from vulnerable public-key cryptography.</p></div>
+</details>
+<details class="faq-item" id="are-tokenized-assets-exposed-to-quantum-risk">
+<summary class="faq-q">Are tokenized funds, stablecoins, and RWAs exposed to post-quantum custody risk?</summary>
+<div class="faq-a"><p>Yes. Tokenized funds, stablecoins, and real-world assets are exposed if their minting, redemption, transfer, admin, bridge, or settlement workflows depend on classical signatures. This includes assets issued on Ethereum, Solana, Polygon, Avalanche, Stellar, Canton, and other classically signed networks. The risk is not limited to asset holders; it affects issuers, transfer agents, custodians, market makers, settlement venues, auditors, administrators, and distribution partners.</p></div>
+</details>
+<details class="faq-item" id="what-about-lattice-based-pq-mpc">
+<summary class="faq-q">Can lattice-based post-quantum signatures solve MPC custody?</summary>
+<div class="faq-a"><p>Lattice-based post-quantum signatures may be more MPC-compatible than SPHINCS+, but they are not the conservative institutional default. Threshold ML-DSA and related approaches remain newer, more complex, and less production-validated than classical MPC custody. They also rely on lattice assumptions rather than hash-based assumptions. For institutions that want conservative, hash-based post-quantum assurance, lattice-based MPC is not equivalent to SPHINCS+ custody support.</p></div>
+</details>
+<details class="faq-item" id="can-existing-blockchains-retrofit-post-quantum-mpc">
+<summary class="faq-q">Can existing blockchains retrofit post-quantum MPC custody support?</summary>
+<div class="faq-a"><p>Existing blockchains can research post-quantum signatures, but retrofitting post-quantum MPC custody is much harder than adding a new signature opcode. A real migration requires new account models, wallet support, custody integrations, validator/client changes, transaction-size management, migration tooling, and governance acceptance. If the chain adopts SPHINCS+ as a simple replacement signature, it may create a custody architecture where conventional MPC cannot efficiently operate.</p></div>
+</details>
+<details class="faq-item" id="how-eternax-supports-mpc-and-sphincs">
+<summary class="faq-q">How does EternaX support MPC custody with SPHINCS+ compliance?</summary>
+<div class="faq-a"><p>EternaX separates custody authorization from post-quantum authentication at the chain level. The custody side can remain compatible with distributed authorization models used by institutional MPC providers, while the chain enforces post-quantum transaction validity through a SPHINCS+-aligned authentication layer. This avoids forcing institutions into a false choice between distributed custody and conservative hash-based post-quantum security. The design is native to the settlement rail, not bolted on after launch.</p></div>
+</details>
+<details class="faq-item" id="what-is-eternax-performance-under-pq">
+<summary class="faq-q">What is EternaX’s performance under post-quantum cryptography?</summary>
+<div class="faq-a"><p>EternaX is designed to keep post-quantum security compatible with institutional market speed. The architecture targets high-throughput settlement while keeping post-quantum authentication overhead structurally lower than simply placing full SPHINCS+ signatures on every transaction. The key claim is not that post-quantum cryptography is free; it is that PQ performance must be engineered at the settlement-layer architecture level, not retrofitted into chains designed around classical signatures.</p></div>
+</details>
+<details class="faq-item" id="what-should-institutions-ask-mpc-providers">
+<summary class="faq-q">What should institutions ask their MPC custody provider about post-quantum risk?</summary>
+<div class="faq-a"><p>Institutions should ask their MPC provider for a written post-quantum roadmap, supported signature schemes, chain migration assumptions, control-plane protections, HSM strategy, lattice-risk posture, SPHINCS+ support, account-migration plan, and expected customer impact before 2030. The key question is not “Do you use MPC?” The key question is “How will this custody stack authorize and settle assets when classical signatures are no longer acceptable?”</p></div>
+</details>
+<details class="faq-item" id="what-should-tokenized-asset-issuers-do-now">
+<summary class="faq-q">What should tokenized asset issuers, stablecoin issuers, and funds do now?</summary>
+<div class="faq-a"><p>Issuers should map every signing authority that can move, mint, burn, freeze, upgrade, bridge, redeem, or administer assets. They should classify which keys are classical, which chains expose public keys, which custody providers control workflows, and which assets have no documented post-quantum migration path. New tokenized assets should avoid inheriting quantum debt by default. For long-duration institutional products, post-quantum settlement should become a distribution and risk-management requirement, not a future compliance footnote.</p></div>
+</details>
+<details class="faq-item" id="is-post-quantum-custody-a-security-or-market-infrastructure-problem">
+<summary class="faq-q">Is post-quantum custody only a security problem?</summary>
+<div class="faq-a"><p>No. Post-quantum custody is a market-infrastructure problem. The institutions that solve it first can offer safer tokenized funds, stronger stablecoin issuance, more credible collateral rails, and better long-duration settlement guarantees. The institutions that delay may face stranded custody workflows, expensive migrations, counterparty pushback, and weaker distribution in regulated tokenized markets. Post-quantum readiness is not only defensive security; it is a trust and distribution edge.</p></div>
+</details>
+<details class="faq-item" id="what-is-eternax">
+<summary class="faq-q">What is EternaX?</summary>
+<div class="faq-a"><p>EternaX is post-quantum market infrastructure for stablecoin issuance, tokenized real-world assets, institutional custody workflows, and settlement. It is designed as a PQ-native Layer 1 where post-quantum authentication, institutional performance, and custody-provider compatibility are engineered into the settlement rail from genesis. The core thesis is simple: institutions should not have to choose between MPC-grade operational control and hash-based post-quantum security.</p></div>
+</details>
+</section>
+</main><!-- /content -->
+
+<!-- ═══ AUTHORS SECTION -->
+<section class="team-section" id="founding-team">
+  <div class="team-inner">
+    <div class="team-label">About the Authors</div>
+    <h2>EternaX Labs | Post-Quantum Financial Infrastructure</h2>
+    <div class="team-grid">
+      <div class="team-card">
+        <div class="flex justify-center mb-3">
+          <img src="./assets/dariia.png" alt="Dariia Porechna" class="w-32 h-32 rounded-full object-cover" loading="eager" itemprop="image">
+        </div>
+        <div class="team-name">Dariia Porechna</div>
+        <div class="team-role">Co-Founder</div>
+        <div class="team-bio">Cryptographer and distributed systems architect. Former Head of Protocol at Subspace. Former Research Engineer at Wolfram|Alpha. Co-author, SILMARILS.</div>
+        <div class="team-links"><a href="https://www.linkedin.com/in/dariia-porechna" target="_blank" rel="noopener">LinkedIn</a> · <a href="https://x.com/FutureDies" target="_blank" rel="noopener">X</a></div>
+      </div>
+      <div class="team-card">
+        <div class="flex justify-center mb-3">
+          <img src="./assets/parthh.png" alt="Paarrthhh Birla" class="w-32 h-32 rounded-full object-cover" loading="eager" itemprop="image">
+        </div>
+        <div class="team-name">Paarrthhh Birla</div>
+        <div class="team-role">Co-Founder</div>
+        <div class="team-bio">Former VP, Growth Office at Polygon. Former Head of Partnerships at Subspace Protocol. Former digital-assets strategy advisor at EYP. MBA, CPA.</div>
+        <div class="team-links"><a href="https://www.linkedin.com/in/paarrthhh-birla-b3607bb4/" target="_blank" rel="noopener">LinkedIn</a> · <a href="https://x.com/paarrthhbirla" target="_blank" rel="noopener">X</a></div>
+      </div>
+      <div class="team-card">
+        <div class="flex justify-center mb-3">
+          <img src="./assets/chen.png" alt="Dr. Chen Feng" class="w-32 h-32 rounded-full object-cover" loading="eager" itemprop="image">
+        </div>
+        <div class="team-name">Dr. Chen Feng</div>
+        <div class="team-role">Chief Scientist</div>
+        <div class="team-bio">Associate Professor, University of British Columbia. PhD, University of Toronto. 100+ peer-reviewed papers across quantum communications, blockchain, and TEE privacy. Co-author, SILMARILS.</div>
+        <div class="team-links"><a href="https://www.linkedin.com/in/chen-feng-75272a37" target="_blank" rel="noopener">LinkedIn</a> · <a href="https://scholar.google.com/citations?user=D8b0l-EAAAAJ" target="_blank" rel="noopener">Google Scholar</a></div>
+      </div>
+    </div>
+  </div>
+</section>
+<section class="connect-section">
+  <div class="connect-inner">
+    <div class="connect-label">Contact</div>
+    <h2>Institutional Inquiries</h2>
+    <p class="connect-intro">For institutional inquiries regarding post-quantum custody risk, MPC provider PQ readiness, hash-based SPHINCS+ migration, tokenized finance post-quantum risk, or EternaX post-quantum settlement infrastructure.</p>
+    <div class="connect-contacts">
+      <div class="connect-person"><span class="name">Paarrthhh Birla</span><span class="connect-sep">-</span><span class="role">Co-Founder</span><span class="connect-sep">-</span><a href="mailto:paarrthhh.b@eternax.ai" class="email">paarrthhh.b@eternax.ai</a></div>
+      <div class="connect-person"><span class="name">Dariia Porechna</span><span class="connect-sep">-</span><span class="role">Co-Founder</span><span class="connect-sep">-</span><a href="mailto:dariia.p@eternax.ai" class="email">dariia.p@eternax.ai</a></div>
+    </div>
+    <div class="connect-actions">
+      <a href="https://eternax.ai" target="_blank" rel="noopener" class="connect-btn primary no-print">eternax.ai</a>
+      <a href="mailto:paarrthhh.b@eternax.ai" class="connect-btn secondary">Contact EternaX</a>
+    </div>
+  </div>
+</section>
+
+<footer class="report-footer">
+  <div class="report-footer-inner">
+    <h3>Scope, Methodology, and Limitations</h3>
+    <p>This report reviews 15 institutional MPC custody providers based on public evidence from official provider pages, regulator-facing disclosures, official trust centres, and reputable financial reporting accessed 9 June 2026. Independent research from Taurus SA (June 2026), NIST, and Chainalysis. Scale figures labelled "company claim" are not independently audited.</p>
+    <p><strong>Authors:</strong> Paarrthhh Birla, Dariia Porechna, Dr. Chen Feng · <a href="https://eternax.ai">EternaX Labs</a> · Published June 2026</p>
+    <p><strong>Disclaimer:</strong> Not investment advice. EternaX Labs has a direct commercial interest in the conclusions of this report. Readers should conduct independent diligence on all claims before making any institutional decision.</p>
+  </div>
+</footer>
+
+<!-- Footer -->
+  <footer class="py-12 border-t" style="background-color: var(--bg); border-color: var(--border);" itemscope itemtype="https://schema.org/WPFooter">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex flex-col sm:flex-row items-start justify-between gap-6 mb-6">
+            <div>
+                <span class="text-lg font-bold" style="color: var(--fg)">eternaX</span>
+                <p class="text-sm mt-1" style="color: var(--fg-70)">Quantum-safe Settlement at Market Speed</p>
+                <div class="text-xs" style="color: var(--fg-70)">&copy; 2026 EternaX Labs</div>
+            </div>
+            <div class="flex items-center gap-4">
+                <a href="https://github.com/eternax-ai" class="text-sm link-muted" itemprop="sameAs">GitHub</a>
+                <a href="https://www.youtube.com/@eternaXlabs" class="text-sm link-muted">YouTube</a>
+                <a href="https://t.me/eternax_official" class="text-sm link-muted" itemprop="sameAs">Telegram</a>
+                <a href="https://x.com/EternaXlabs" class="text-sm link-muted" itemprop="sameAs">X (Twitter)</a>
+                <a href="https://www.linkedin.com/company/eternax-labs" class="text-sm link-muted" itemprop="sameAs">LinkedIn</a>
+            </div>
+        </div>
+        <div class="flex items-center gap-4 pt-4 border-t" style="border-color: var(--border);">
+            <a href="about.html" class="text-sm link-muted">About</a>
+            <a href="glossary.html" class="text-sm link-muted">Glossary</a>
+        </div>
+    </div>
+</footer>
+<script>
+// Ensure FAQ answers render in print/PDF output by expanding <details>.
+(function () {
+  function expandFaqDetails() {
+    document.querySelectorAll('details.faq-item').forEach((d) => d.setAttribute('open', ''));
+  }
+  try {
+    if (window.matchMedia && window.matchMedia('print').matches) expandFaqDetails();
+    window.addEventListener('beforeprint', expandFaqDetails);
+  } catch (e) {}
+})();
+
+document.addEventListener('DOMContentLoaded', function() {
+  const menuButton = document.getElementById('mobile-menu-button');
+  const mobileMenu = document.getElementById('mobile-menu');
+  const iconMenu = document.getElementById('icon-menu');
+  const iconClose = document.getElementById('icon-close');
+
+  function closeMobileMenu() {
+    if (!mobileMenu) return;
+    mobileMenu.classList.add('hidden');
+    if (menuButton) menuButton.setAttribute('aria-expanded', 'false');
+    if (iconMenu) iconMenu.classList.remove('hidden');
+    if (iconClose) iconClose.classList.add('hidden');
+  }
+
+  function openMobileMenu() {
+    if (!mobileMenu) return;
+    mobileMenu.classList.remove('hidden');
+    if (menuButton) menuButton.setAttribute('aria-expanded', 'true');
+    if (iconMenu) iconMenu.classList.add('hidden');
+    if (iconClose) iconClose.classList.remove('hidden');
+  }
+
+  if (menuButton && mobileMenu) {
+    menuButton.addEventListener('click', () => {
+      const isHidden = mobileMenu.classList.contains('hidden');
+      if (isHidden) openMobileMenu();
+      else closeMobileMenu();
+    });
+
+    mobileMenu.querySelectorAll('a').forEach((a) => {
+      a.addEventListener('click', () => closeMobileMenu());
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') closeMobileMenu();
+    });
+
+    window.addEventListener('resize', () => {
+      if (window.innerWidth >= 768) closeMobileMenu();
+    });
+  }
+});
+</script>
+</body>
+</html>

--- a/post_quantum_mpc_custody_crisis_hash_based_sphincs_institutional.html
+++ b/post_quantum_mpc_custody_crisis_hash_based_sphincs_institutional.html
@@ -30,7 +30,7 @@
 <meta content="EternaX Labs" property="og:site_name"/>
 <meta content="en_US" property="og:locale"/>
 <meta content="https://eternax.ai" property="article:publisher"/>
-<meta content="2026-06-09" property="article:published_time"/>
+<meta content="2026-06-12" property="article:published_time"/>
 <meta content="summary_large_image" name="twitter:card"/>
 <meta content="https://eternax.ai/assets/preview.png" name="twitter:image"/>
 <meta content="EternaX - Post-Quantum Market Infrastructure" name="twitter:image:alt"/>
@@ -137,7 +137,7 @@
     "@type": "Organization",
     "name": "EternaX Labs"
   },
-  "datePublished": "2026-06-09",
+  "datePublished": "2026-06-12",
   "url": "https://eternax.ai/post-quantum-mpc-custody-crisis-hash-based-sphincs-institutional-risk-map-2026.html",
   "inLanguage": "en",
   "about": [
@@ -163,7 +163,7 @@
     "https://www.nextgov.com/emerging-tech/2023/08/new-post-quantum-cryptography-guidance-offers-first-steps-toward-migration/389595/",
     "https://industrialcyber.co/cisa/cisa-nsa-nist-factsheet-addresses-migration-to-post-quantum-cryptography-ahead-of-standards-rollout/"
   ],
-  "dateModified": "2026-06-10"
+  "dateModified": "2026-06-12"
 }</script>
 <script type="application/ld+json">
 {
@@ -1161,7 +1161,7 @@ summary.faq-q:hover{color:var(--navy-hover)}
 <!-- ═══ COVER -->
 <header class="cover" role="banner">
 <div class="cover-inner">
-  <div class="cover-eyebrow">EternaX Research · Institutional MPC Custody Risk Map · June 2026</div>
+  <div class="cover-eyebrow">EternaX Research · Institutional MPC Custody Risk Map · 12 June 2026</div>
   <h1 class="cover-title">The Post-Quantum Institutional MPC Custody Crisis 2026: 15 Providers, $10 Trillion Protected, Zero Post-Quantum Safe</h1>
   <p class="cover-subtitle">Why hash-based post-quantum signatures (SPHINCS+ / SLH-DSA, NIST FIPS 205) are mathematically incompatible with MPC custody, and what institutions should do about it</p>
   <div class="cover-meta">
@@ -1842,7 +1842,7 @@ summary.faq-q:hover{color:var(--navy-hover)}
   <div class="report-footer-inner">
     <h3>Scope, Methodology, and Limitations</h3>
     <p>This report reviews 15 institutional MPC custody providers based on public evidence from official provider pages, regulator-facing disclosures, official trust centres, and reputable financial reporting accessed 9 June 2026. Independent research from Taurus SA (June 2026), NIST, and Chainalysis. Scale figures labelled "company claim" are not independently audited.</p>
-    <p><strong>Authors:</strong> Paarrthhh Birla, Dariia Porechna, Dr. Chen Feng · <a href="https://eternax.ai">EternaX Labs</a> · Published June 2026</p>
+    <p><strong>Authors:</strong> Paarrthhh Birla, Dariia Porechna, Dr. Chen Feng · <a href="https://eternax.ai">EternaX Labs</a> · Published 12 June 2026</p>
     <p><strong>Disclaimer:</strong> Not investment advice. EternaX Labs has a direct commercial interest in the conclusions of this report. Readers should conduct independent diligence on all claims before making any institutional decision.</p>
   </div>
 </footer>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -19,6 +19,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://eternax.ai/post_quantum_mpc_custody_crisis_hash_based_sphincs_institutional.html</loc>
+    <lastmod>2026-06-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://eternax.ai/post-quantum-cryptography-risk-framework-for-institutions.html</loc>
     <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## Summary
- Publish the Post-Quantum MPC Custody Crisis 2026 report with institutional report styling (navbar, cover, team section, footer, shared CSS).
- Add the report to the Quantum Risk Reports navbar dropdown (top entry) and `sitemap.xml`.
- Set publish metadata and on-page dates to 12 June 2026.

## Test plan
- [ ] Open `post_quantum_mpc_custody_crisis_hash_based_sphincs_institutional.html` locally and verify cover, timeline, FAQs, team, and footer render correctly
- [ ] Confirm navbar dropdown and mobile menu link to the new report
- [ ] Verify sitemap includes the report URL with `lastmod` 2026-06-12
- [ ] Check responsive layout for the Deprecation Clock timeline on mobile